### PR TITLE
feat: add Python full patcher and Windows proxy DLL

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -1,15 +1,18 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: build-version-dll
+name: cmake_multi_platform_workflow
 
 on:
     push:
         branches: [main]
         paths: &paths
             - "src/**"
-            - "cmake/toolchains/llvm_mingw.cmake"
-            - "CMakeLists.txt"
+            - "cmake/**"
+            - "**/*.cmake"
+            - "**/*.c"
+            - "**/*.h"
+            - "**/CMakeLists.txt"
             - "CMakePresets.json"
-            - ".github/workflows/cmake_multi_platform.yml"
+            - ".github/workflows/**"
     pull_request:
         branches: [main]
         paths: *paths
@@ -25,49 +28,47 @@ permissions:
     contents: read
 
 jobs:
-    llvm-mingw-x86_64:
-        name: Windows x86-64 DLL / LLVM-MinGW
-        runs-on: ubuntu-latest
+    build:
+        name: ${{ matrix.name }}
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - name: win-msvc-x64
+                      os: windows-2026
+                      preset: msvc-full
+                      artifact: win-msvc-x64
+                      package: build/msvc/*.zip
+                    - name: win-llvm-mingw-x64
+                      os: ubuntu-latest
+                      preset: llvm-mingw-x86_64-full
+                      artifact: win-llvm-mingw-x64
+                      package: build/llvm-mingw-x86_64/*.tar.xz
+        runs-on: ${{ matrix.os }}
         steps:
             - name: checkout
               uses: actions/checkout@v7
 
-            - name: install build tools
+            - name: install Ninja
+              if: runner.os == 'Linux'
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends ninja-build
 
             - name: cache LLVM-MinGW
+              if: runner.os == 'Linux'
               uses: actions/cache@v6
               with:
                   path: llvm_mingw
                   key: llvm-mingw-${{ hashFiles('cmake/toolchains/llvm_mingw.cmake') }}
 
-            - name: build and package
-              run: cmake --workflow --preset llvm-mingw-x86_64-full
+            - name: build
+              run: cmake --workflow --preset ${{ matrix.preset }}
 
-            - name: upload package
+            - name: upload
               uses: actions/upload-artifact@v7
               with:
-                  name: version-dll-llvm-mingw-x86_64
-                  path: build/llvm-mingw-x86_64/*.tar.xz
-                  if-no-files-found: error
-                  compression-level: 0
-
-    msvc-x86_64:
-        name: Windows x86-64 DLL / MSVC
-        runs-on: windows-2026
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
-
-            - name: build and package
-              run: cmake --workflow --preset msvc-full
-
-            - name: upload package
-              uses: actions/upload-artifact@v7
-              with:
-                  name: version-dll-msvc-x86_64
-                  path: build/msvc/*.zip
+                  name: ${{ matrix.artifact }}
+                  path: ${{ matrix.package }}
                   if-no-files-found: error
                   compression-level: 0

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -2,180 +2,122 @@
 name: cmake_multiplatform_workflow
 
 on:
-    push:
-        branches: [main]
-        paths: &paths
-            - "src/**"
-            - "include/**"
-            - "cmake/**"
-            - "**/*.cmake"
-            - "**/*.cpp"
-            - "**/*.hpp"
-            - "**/*.c"
-            - "**/*.h"
-            - "**/*.cxx"
-            - "**/*.hxx"
-            - "**/CMakeLists.txt"
-            - "CMakePresets.json"
-            - ".github/workflows/**"
-            - "android-project/**"
-    pull_request:
-        branches: [main]
-        paths: *paths
-    release:
-        types: [published]
-    workflow_dispatch:
+  push:
+    branches: [main]
+    paths: &paths
+      - "src/**"
+      - "include/**"
+      - "cmake/**"
+      - "**/*.cmake"
+      - "**/*.cpp"
+      - "**/*.hpp"
+      - "**/*.c"
+      - "**/*.h"
+      - "**/*.cxx"
+      - "**/*.hxx"
+      - "**/CMakeLists.txt"
+      - "CMakePresets.json"
+      - ".github/workflows/**"
+  pull_request:
+    branches: [main]
+    paths: *paths
+  release:
+    types: [published]
+  workflow_dispatch:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-    contents: read
+  contents: read
 
 env:
-    CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
 
 jobs:
-    # ── native builds ───────────────────────────────────────────────────────────
-    native:
-        name: native / ${{ matrix.artifact-name }}
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - os: ubuntu-latest
-                      preset: clang-full
-                      artifact-name: linux-clang
-                    - os: ubuntu-latest
-                      preset: gcc-full
-                      artifact-name: linux-gcc
-                    - os: windows-2026 # Pin to windows-2022 for VS 2022
-                      preset: msvc-full
-                      artifact-name: windows-msvc
+  # ── native builds ───────────────────────────────────────────────────────────
+  native:
+    name: native / ${{ matrix.artifact-name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2026 # Pin to windows-2022 for VS 2022
+            preset: msvc-full
+            artifact-name: windows-msvc
 
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
 
-            - name: install linux system deps
-              if: runner.os == 'Linux'
-              run: |
-                  sudo apt-get update -qq
-                  sudo apt-get install -y --no-install-recommends \
-                    ninja-build clang \
-                    doxygen graphviz \
-                    libwayland-dev libxkbcommon-dev \
-                    libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev \
-                    libdbus-1-dev libudev-dev libasound2-dev
+      - name: cache cpm sources
+        uses: actions/cache@v6
+        with:
+          path: .cpm_cache
+          key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: cpm-${{ matrix.artifact-name }}-
 
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: .cpm_cache
-                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-${{ matrix.artifact-name }}-
+      - name: build
+        run: cmake --workflow --preset ${{ matrix.preset }}
 
-            - name: build
-              run: cmake --workflow --preset ${{ matrix.preset }}
+      - name: upload zip artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact-name }}-zip
+          path: build/**/*.zip
+          if-no-files-found: ignore
+          compression-level: 0
 
-            # ── Documentation (Clang only) ───────────────────────────────────
-            - name: build documentation
-              if: matrix.preset == 'clang-full'
-              run: cmake --build --preset clang-docs
+      - name: upload tgz artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact-name }}-tgz
+          path: build/**/*.tar.gz
+          if-no-files-found: ignore
+          compression-level: 0
 
-            - name: verify documentation
-              if: matrix.preset == 'clang-full'
-              run: |
-                  index_path="build/clang/generated_docs/html/index.html"
-                  if [[ ! -f "${index_path}" ]]; then
-                    echo "::error::Documentation index not found at ${index_path}"
-                    exit 1
-                  fi
-                  echo "Documentation ready: ${index_path}"
-                  du -sh build/clang/generated_docs/html/
-                  find build/clang/generated_docs/html -maxdepth 1 -type f | sort
+  # ── cross-compile: Linux → Windows (llvm-mingw) ─────────────────────────────
+  cross-windows:
+    name: cross-windows / ${{ matrix.artifact-name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - preset: llvm-mingw-x86_64-full
+            artifact-name: windows-mingw-x86_64
 
-            - name: upload documentation artifact
-              if: matrix.preset == 'clang-full'
-              uses: actions/upload-artifact@v7
-              with:
-                  name: doxygen_html_${{ github.run_id }}
-                  path: build/clang/generated_docs/html/
-                  retention-days: 30
-                  if-no-files-found: error
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
 
-            - name: documentation summary
-              if: matrix.preset == 'clang-full' && always()
-              run: |
-                  echo "## Documentation build result" >> $GITHUB_STEP_SUMMARY
-                  echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-                  echo "- Trigger: \`${{ github.event_name }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Ref: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Preset: \`clang-docs\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Artifact: \`doxygen_html_${{ github.run_id }}\`" >> $GITHUB_STEP_SUMMARY
-            # ──────────────────────────────────────────────────────────────────
-            - name: upload zip artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-zip
-                  path: build/**/*.zip
-                  if-no-files-found: ignore
-                  compression-level: 0
+      - name: install build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ninja-build
 
-            - name: upload tgz artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-tgz
-                  path: build/**/*.tar.gz
-                  if-no-files-found: ignore
-                  compression-level: 0
+      - name: cache llvm-mingw toolchain
+        uses: actions/cache@v6
+        with:
+          path: llvm_mingw
+          key: llvm-mingw-${{ hashFiles('cmake/toolchains/llvm_mingw.cmake') }}
 
-    # ── cross-compile: Linux → Windows (llvm-mingw) ─────────────────────────────
-    cross-windows:
-        name: cross-windows / ${{ matrix.artifact-name }}
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - preset: llvm-mingw-x86_64-full
-                      artifact-name: windows-mingw-x86_64
-                    - preset: llvm-mingw-i686-full
-                      artifact-name: windows-mingw-i686
-                    - preset: llvm-mingw-aarch64-full
-                      artifact-name: windows-mingw-aarch64
+      - name: cache cpm sources
+        uses: actions/cache@v6
+        with:
+          path: .cpm_cache
+          key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: cpm-${{ matrix.artifact-name }}-
 
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
+      - name: build
+        run: cmake --workflow --preset ${{ matrix.preset }}
 
-            - name: install build tools
-              run: |
-                  sudo apt-get update -qq
-                  sudo apt-get install -y --no-install-recommends ninja-build
-
-            - name: cache llvm-mingw toolchain
-              uses: actions/cache@v6
-              with:
-                  path: llvm_mingw
-                  key: llvm-mingw-${{ hashFiles('cmake/toolchains/llvm_mingw.cmake') }}
-
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: .cpm_cache
-                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-${{ matrix.artifact-name }}-
-
-            - name: build
-              run: cmake --workflow --preset ${{ matrix.preset }}
-
-            - name: upload txz artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-txz
-                  path: build/**/*.tar.xz
-                  if-no-files-found: ignore
-                  compression-level: 0
+      - name: upload txz artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact-name }}-txz
+          path: build/**/*.tar.xz
+          if-no-files-found: ignore
+          compression-level: 0

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -1,18 +1,24 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: cmake_multi_platform_workflow
+name: cmake_multiplatform_workflow
 
 on:
     push:
         branches: [main]
         paths: &paths
             - "src/**"
+            - "include/**"
             - "cmake/**"
             - "**/*.cmake"
+            - "**/*.cpp"
+            - "**/*.hpp"
             - "**/*.c"
             - "**/*.h"
+            - "**/*.cxx"
+            - "**/*.hxx"
             - "**/CMakeLists.txt"
             - "CMakePresets.json"
             - ".github/workflows/**"
+            - "android-project/**"
     pull_request:
         branches: [main]
         paths: *paths
@@ -27,48 +33,149 @@ concurrency:
 permissions:
     contents: read
 
+env:
+    CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
+
 jobs:
-    build:
-        name: ${{ matrix.name }}
+    # ── native builds ───────────────────────────────────────────────────────────
+    native:
+        name: native / ${{ matrix.artifact-name }}
+        runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - name: win-msvc-x64
-                      os: windows-2026
+                    - os: ubuntu-latest
+                      preset: clang-full
+                      artifact-name: linux-clang
+                    - os: ubuntu-latest
+                      preset: gcc-full
+                      artifact-name: linux-gcc
+                    - os: windows-2026 # Pin to windows-2022 for VS 2022
                       preset: msvc-full
-                      artifact: win-msvc-x64
-                      package: build/msvc/*.zip
-                    - name: win-llvm-mingw-x64
-                      os: ubuntu-latest
-                      preset: llvm-mingw-x86_64-full
-                      artifact: win-llvm-mingw-x64
-                      package: build/llvm-mingw-x86_64/*.tar.xz
-        runs-on: ${{ matrix.os }}
+                      artifact-name: windows-msvc
+
         steps:
             - name: checkout
               uses: actions/checkout@v7
 
-            - name: install Ninja
+            - name: install linux system deps
               if: runner.os == 'Linux'
+              run: |
+                  sudo apt-get update -qq
+                  sudo apt-get install -y --no-install-recommends \
+                    ninja-build clang \
+                    doxygen graphviz \
+                    libwayland-dev libxkbcommon-dev \
+                    libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev \
+                    libdbus-1-dev libudev-dev libasound2-dev
+
+            - name: cache cpm sources
+              uses: actions/cache@v6
+              with:
+                  path: .cpm_cache
+                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+                  restore-keys: cpm-${{ matrix.artifact-name }}-
+
+            - name: build
+              run: cmake --workflow --preset ${{ matrix.preset }}
+
+            # ── Documentation (Clang only) ───────────────────────────────────
+            - name: build documentation
+              if: matrix.preset == 'clang-full'
+              run: cmake --build --preset clang-docs
+
+            - name: verify documentation
+              if: matrix.preset == 'clang-full'
+              run: |
+                  index_path="build/clang/generated_docs/html/index.html"
+                  if [[ ! -f "${index_path}" ]]; then
+                    echo "::error::Documentation index not found at ${index_path}"
+                    exit 1
+                  fi
+                  echo "Documentation ready: ${index_path}"
+                  du -sh build/clang/generated_docs/html/
+                  find build/clang/generated_docs/html -maxdepth 1 -type f | sort
+
+            - name: upload documentation artifact
+              if: matrix.preset == 'clang-full'
+              uses: actions/upload-artifact@v7
+              with:
+                  name: doxygen_html_${{ github.run_id }}
+                  path: build/clang/generated_docs/html/
+                  retention-days: 30
+                  if-no-files-found: error
+
+            - name: documentation summary
+              if: matrix.preset == 'clang-full' && always()
+              run: |
+                  echo "## Documentation build result" >> $GITHUB_STEP_SUMMARY
+                  echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- Trigger: \`${{ github.event_name }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- Ref: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- Preset: \`clang-docs\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- Artifact: \`doxygen_html_${{ github.run_id }}\`" >> $GITHUB_STEP_SUMMARY
+            # ──────────────────────────────────────────────────────────────────
+            - name: upload zip artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: ${{ matrix.artifact-name }}-zip
+                  path: build/**/*.zip
+                  if-no-files-found: ignore
+                  compression-level: 0
+
+            - name: upload tgz artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: ${{ matrix.artifact-name }}-tgz
+                  path: build/**/*.tar.gz
+                  if-no-files-found: ignore
+                  compression-level: 0
+
+    # ── cross-compile: Linux → Windows (llvm-mingw) ─────────────────────────────
+    cross-windows:
+        name: cross-windows / ${{ matrix.artifact-name }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - preset: llvm-mingw-x86_64-full
+                      artifact-name: windows-mingw-x86_64
+                    - preset: llvm-mingw-i686-full
+                      artifact-name: windows-mingw-i686
+                    - preset: llvm-mingw-aarch64-full
+                      artifact-name: windows-mingw-aarch64
+
+        steps:
+            - name: checkout
+              uses: actions/checkout@v7
+
+            - name: install build tools
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends ninja-build
 
-            - name: cache LLVM-MinGW
-              if: runner.os == 'Linux'
+            - name: cache llvm-mingw toolchain
               uses: actions/cache@v6
               with:
                   path: llvm_mingw
                   key: llvm-mingw-${{ hashFiles('cmake/toolchains/llvm_mingw.cmake') }}
 
+            - name: cache cpm sources
+              uses: actions/cache@v6
+              with:
+                  path: .cpm_cache
+                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+                  restore-keys: cpm-${{ matrix.artifact-name }}-
+
             - name: build
               run: cmake --workflow --preset ${{ matrix.preset }}
 
-            - name: upload
+            - name: upload txz artifact
               uses: actions/upload-artifact@v7
               with:
-                  name: ${{ matrix.artifact }}
-                  path: ${{ matrix.package }}
-                  if-no-files-found: error
+                  name: ${{ matrix.artifact-name }}-txz
+                  path: build/**/*.tar.xz
+                  if-no-files-found: ignore
                   compression-level: 0

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -1,24 +1,15 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: cmake_multiplatform_workflow
+name: build-version-dll
 
 on:
     push:
         branches: [main]
         paths: &paths
             - "src/**"
-            - "include/**"
-            - "cmake/**"
-            - "**/*.cmake"
-            - "**/*.cpp"
-            - "**/*.hpp"
-            - "**/*.c"
-            - "**/*.h"
-            - "**/*.cxx"
-            - "**/*.hxx"
-            - "**/CMakeLists.txt"
+            - "cmake/toolchains/llvm_mingw.cmake"
+            - "CMakeLists.txt"
             - "CMakePresets.json"
-            - ".github/workflows/**"
-            - "android-project/**"
+            - ".github/workflows/cmake_multi_platform.yml"
     pull_request:
         branches: [main]
         paths: *paths
@@ -33,120 +24,10 @@ concurrency:
 permissions:
     contents: read
 
-env:
-    CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
-
 jobs:
-    # ── native builds ───────────────────────────────────────────────────────────
-    native:
-        name: native / ${{ matrix.artifact-name }}
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - os: ubuntu-latest
-                      preset: clang-full
-                      artifact-name: linux-clang
-                    - os: ubuntu-latest
-                      preset: gcc-full
-                      artifact-name: linux-gcc
-                    - os: windows-2026 # Pin to windows-2022 for VS 2022
-                      preset: msvc-full
-                      artifact-name: windows-msvc
-
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
-
-            - name: install linux system deps
-              if: runner.os == 'Linux'
-              run: |
-                  sudo apt-get update -qq
-                  sudo apt-get install -y --no-install-recommends \
-                    ninja-build clang \
-                    doxygen graphviz \
-                    libwayland-dev libxkbcommon-dev \
-                    libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev \
-                    libdbus-1-dev libudev-dev libasound2-dev
-
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: .cpm_cache
-                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-${{ matrix.artifact-name }}-
-
-            - name: build
-              run: cmake --workflow --preset ${{ matrix.preset }}
-
-            # ── Documentation (Clang only) ───────────────────────────────────
-            - name: build documentation
-              if: matrix.preset == 'clang-full'
-              run: cmake --build --preset clang-docs
-
-            - name: verify documentation
-              if: matrix.preset == 'clang-full'
-              run: |
-                  index_path="build/clang/generated_docs/html/index.html"
-                  if [[ ! -f "${index_path}" ]]; then
-                    echo "::error::Documentation index not found at ${index_path}"
-                    exit 1
-                  fi
-                  echo "Documentation ready: ${index_path}"
-                  du -sh build/clang/generated_docs/html/
-                  find build/clang/generated_docs/html -maxdepth 1 -type f | sort
-
-            - name: upload documentation artifact
-              if: matrix.preset == 'clang-full'
-              uses: actions/upload-artifact@v7
-              with:
-                  name: doxygen_html_${{ github.run_id }}
-                  path: build/clang/generated_docs/html/
-                  retention-days: 30
-                  if-no-files-found: error
-
-            - name: documentation summary
-              if: matrix.preset == 'clang-full' && always()
-              run: |
-                  echo "## Documentation build result" >> $GITHUB_STEP_SUMMARY
-                  echo "- Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-                  echo "- Trigger: \`${{ github.event_name }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Ref: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Preset: \`clang-docs\`" >> $GITHUB_STEP_SUMMARY
-                  echo "- Artifact: \`doxygen_html_${{ github.run_id }}\`" >> $GITHUB_STEP_SUMMARY
-            # ──────────────────────────────────────────────────────────────────
-            - name: upload zip artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-zip
-                  path: build/**/*.zip
-                  if-no-files-found: ignore
-                  compression-level: 0
-
-            - name: upload tgz artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-tgz
-                  path: build/**/*.tar.gz
-                  if-no-files-found: ignore
-                  compression-level: 0
-
-    # ── cross-compile: Linux → Windows (llvm-mingw) ─────────────────────────────
-    cross-windows:
-        name: cross-windows / ${{ matrix.artifact-name }}
+    llvm-mingw-x86_64:
+        name: Windows x86-64 DLL / LLVM-MinGW
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - preset: llvm-mingw-x86_64-full
-                      artifact-name: windows-mingw-x86_64
-                    - preset: llvm-mingw-i686-full
-                      artifact-name: windows-mingw-i686
-                    - preset: llvm-mingw-aarch64-full
-                      artifact-name: windows-mingw-aarch64
-
         steps:
             - name: checkout
               uses: actions/checkout@v7
@@ -156,26 +37,37 @@ jobs:
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends ninja-build
 
-            - name: cache llvm-mingw toolchain
+            - name: cache LLVM-MinGW
               uses: actions/cache@v6
               with:
                   path: llvm_mingw
                   key: llvm-mingw-${{ hashFiles('cmake/toolchains/llvm_mingw.cmake') }}
 
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: .cpm_cache
-                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-${{ matrix.artifact-name }}-
+            - name: build and package
+              run: cmake --workflow --preset llvm-mingw-x86_64-full
 
-            - name: build
-              run: cmake --workflow --preset ${{ matrix.preset }}
-
-            - name: upload txz artifact
+            - name: upload package
               uses: actions/upload-artifact@v7
               with:
-                  name: ${{ matrix.artifact-name }}-txz
-                  path: build/**/*.tar.xz
-                  if-no-files-found: ignore
+                  name: version-dll-llvm-mingw-x86_64
+                  path: build/llvm-mingw-x86_64/*.tar.xz
+                  if-no-files-found: error
+                  compression-level: 0
+
+    msvc-x86_64:
+        name: Windows x86-64 DLL / MSVC
+        runs-on: windows-2026
+        steps:
+            - name: checkout
+              uses: actions/checkout@v7
+
+            - name: build and package
+              run: cmake --workflow --preset msvc-full
+
+            - name: upload package
+              uses: actions/upload-artifact@v7
+              with:
+                  name: version-dll-msvc-x86_64
+                  path: build/msvc/*.zip
+                  if-no-files-found: error
                   compression-level: 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,76 +1,10 @@
 cmake_minimum_required(VERSION 3.31)
 
 project(
-    cxx_project
+    wemod_enhancer
     VERSION 1.0.0
-    DESCRIPTION "My awesome C/C++ project!"
-    HOMEPAGE_URL "https://github.com/e-gleba/cxx-skeleton"
-    LANGUAGES C CXX)
-
-# CMAKE_CURRENT_LIST_DIR is used instead of CMAKE_SOURCE_DIR so
-# that this file works correctly if the project is ever consumed
-# as a subdirectory of a larger build.
-# Ref: Professional CMake §8.3 "Project-relative Variables"
-list(
-    APPEND
-    CMAKE_PREFIX_PATH
-    "${CMAKE_CURRENT_LIST_DIR}/cmake"
-    "${CMAKE_CURRENT_LIST_DIR}/cmake/description"
-    "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
-
-# When cross-compiling, CMAKE_FIND_ROOT_PATH_MODE_PACKAGE is
-# typically set to ONLY in the toolchain file. That restricts
-# find_package() to searching only under CMAKE_FIND_ROOT_PATH
-# and CMAKE_SYSROOT — our local cmake/ dirs wouldn't be found.
-# Adding them to CMAKE_FIND_ROOT_PATH fixes this
-if(CMAKE_CROSSCOMPILING)
-    list(
-        APPEND
-        CMAKE_FIND_ROOT_PATH
-        "${CMAKE_CURRENT_LIST_DIR}/cmake"
-        "${CMAKE_CURRENT_LIST_DIR}/cmake/description"
-        "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
-endif()
-
-find_package(cpm CONFIG REQUIRED)
-
-find_package(warnings CONFIG REQUIRED)
-
-if(PROJECT_IS_TOP_LEVEL)
-    find_package(clang_format CONFIG REQUIRED)
-    find_package(clang_tidy CONFIG REQUIRED)
-    find_package(clang_doc CONFIG REQUIRED)
-    find_package(cpplint CONFIG REQUIRED)
-    find_package(ct_doxygen CONFIG REQUIRED)
-endif()
+    DESCRIPTION "Cross-platform Wand/WeMod Electron patcher and Windows ASAR fuse proxy"
+    HOMEPAGE_URL "https://github.com/e-gleba/wemod_enhancer"
+    LANGUAGES C)
 
 add_subdirectory(src)
-
-# CTest, CPack, and install rules for top-level metadata files
-# should only run when this project owns the build. If another
-# project pulls us in via add_subdirectory() or FetchContent,
-# it controls testing and packaging — we should not interfere.
-# Ref: Professional CMake §8.3, §39 "FetchContent"
-if(PROJECT_IS_TOP_LEVEL)
-    # include(CTest) creates the BUILD_TESTING cache option
-    # (default ON) and sets up CDash integration.
-    include(CTest)
-
-    if(BUILD_TESTING)
-        add_subdirectory(tests)
-    endif()
-
-    include(GNUInstallDirs)
-    find_package(package_description CONFIG REQUIRED)
-
-    # Append processor to system name so packages for
-    # different architectures don't collide (e.g.
-    # "Windows-x86_64" vs "Windows-aarch64").
-    string(APPEND CPACK_SYSTEM_NAME "-${CMAKE_SYSTEM_PROCESSOR}")
-
-    # include(CPack) must come AFTER all CPACK_* variables
-    # are set — it reads them at include-time and ignores
-    # any changes made afterward.
-    # Ref: Professional CMake §36.1 "Packaging Basics"
-    include(CPack)
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,13 @@ project(
     LANGUAGES C)
 
 add_subdirectory(src)
+
+if(PROJECT_IS_TOP_LEVEL)
+    set(CPACK_PACKAGE_NAME "wemod-enhancer")
+    set(CPACK_PACKAGE_VENDOR "e-gleba")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Wand/WeMod Electron proxy DLL")
+    set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+    set(CPACK_PACKAGE_FILE_NAME
+        "${CPACK_PACKAGE_NAME}-${PROJECT_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+    include(CPack)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,25 +8,27 @@
     },
     "configurePresets": [
         {
-            "name": "base",
-            "displayName": "Base Configuration",
-            "description": "Ninja Multi-Config, compile_commands.json, color diagnostics, C++20 module scanning disabled",
-            "hidden": true,
+            "name": "llvm-mingw-x86_64",
+            "displayName": "LLVM-MinGW Windows x86-64",
+            "description": "Cross-compile version.dll for Windows x86-64 from Linux",
             "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/cmake/toolchains/llvm_mingw.cmake",
             "cacheVariables": {
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-                "CMAKE_COLOR_DIAGNOSTICS": "ON",
-                "CMAKE_CXX_SCAN_FOR_MODULES": "OFF",
-                "FETCHCONTENT_QUIET": "OFF"
+                "CMAKE_SYSTEM_PROCESSOR": "x86_64"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
             }
         },
         {
             "name": "msvc",
-            "displayName": "Microsoft Visual C++",
-            "description": "MSVC with VS 2026. CMAKE_EXPORT_COMPILE_COMMANDS is inherited but ignored by the VS generator.",
-            "inherits": "base",
+            "displayName": "Microsoft Visual C++ x86-64",
+            "description": "Build version.dll natively on Windows with MSVC",
             "generator": "Visual Studio 18 2026",
+            "binaryDir": "${sourceDir}/build/${presetName}",
             "architecture": {
                 "value": "x64",
                 "strategy": "set"
@@ -40,396 +42,57 @@
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
             }
-        },
-        {
-            "name": "llvm-mingw-base",
-            "displayName": "LLVM-MinGW Base",
-            "description": "Cross-compilation from Linux to Windows via llvm-mingw toolchain",
-            "hidden": true,
-            "inherits": "base",
-            "toolchainFile": "${sourceDir}/cmake/toolchains/llvm_mingw.cmake",
-            "cacheVariables": {
-                "CMAKE_SYSTEM_NAME": "Windows"
-            },
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            }
-        },
-        {
-            "name": "llvm-mingw-i686",
-            "displayName": "LLVM-MinGW Win32 (i686)",
-            "description": "Cross-compile for Windows 32-bit x86",
-            "inherits": "llvm-mingw-base",
-            "cacheVariables": {
-                "CMAKE_SYSTEM_PROCESSOR": "i686"
-            }
-        },
-        {
-            "name": "llvm-mingw-x86_64",
-            "displayName": "LLVM-MinGW Win64 (x86_64)",
-            "description": "Cross-compile for Windows 64-bit x86",
-            "inherits": "llvm-mingw-base",
-            "cacheVariables": {
-                "CMAKE_SYSTEM_PROCESSOR": "x86_64"
-            }
-        },
-        {
-            "name": "llvm-mingw-aarch64",
-            "displayName": "LLVM-MinGW WinARM64 (aarch64)",
-            "description": "Cross-compile for Windows on ARM64",
-            "inherits": "llvm-mingw-base",
-            "cacheVariables": {
-                "CMAKE_SYSTEM_PROCESSOR": "aarch64"
-            }
-        },
-        {
-            "name": "clang",
-            "displayName": "LLVM Clang (native)",
-            "description": "Native build with system Clang/Clang++",
-            "inherits": "base",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++"
-            }
-        },
-        {
-            "name": "gcc",
-            "displayName": "GNU Compiler Collection (native)",
-            "description": "Native build with system GCC/G++",
-            "inherits": "base",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++"
-            }
         }
     ],
     "buildPresets": [
         {
-            "name": "build-release",
-            "hidden": true,
-            "configuration": "Release"
-        },
-        {
-            "name": "build-debug",
-            "hidden": true,
-            "configuration": "Debug"
-        },
-        {
-            "name": "msvc-release",
-            "displayName": "MSVC (Release)",
-            "configurePreset": "msvc",
-            "inherits": "build-release"
-        },
-        {
-            "name": "msvc-debug",
-            "displayName": "MSVC (Debug)",
-            "configurePreset": "msvc",
-            "inherits": "build-debug"
-        },
-        {
-            "name": "llvm-mingw-i686",
-            "displayName": "LLVM-MinGW Win32 (Release)",
-            "configurePreset": "llvm-mingw-i686",
-            "inherits": "build-release"
-        },
-        {
             "name": "llvm-mingw-x86_64",
-            "displayName": "LLVM-MinGW Win64 (Release)",
+            "displayName": "LLVM-MinGW Windows x86-64 Release",
             "configurePreset": "llvm-mingw-x86_64",
-            "inherits": "build-release"
-        },
-        {
-            "name": "llvm-mingw-aarch64",
-            "displayName": "LLVM-MinGW WinARM64 (Release)",
-            "configurePreset": "llvm-mingw-aarch64",
-            "inherits": "build-release"
-        },
-        {
-            "name": "clang-release",
-            "displayName": "Clang (Release)",
-            "configurePreset": "clang",
-            "inherits": "build-release"
-        },
-        {
-            "name": "clang-debug",
-            "displayName": "Clang (Debug)",
-            "configurePreset": "clang",
-            "inherits": "build-debug"
-        },
-        {
-            "name": "clang-docs",
-            "displayName": "Clang (Documentation)",
-            "description": "Generate Doxygen documentation only",
-            "configurePreset": "clang",
-            "inherits": "build-release",
-            "targets": [
-                "docs"
-            ]
-        },
-        {
-            "name": "gcc-release",
-            "displayName": "GCC (Release)",
-            "configurePreset": "gcc",
-            "inherits": "build-release"
-        },
-        {
-            "name": "gcc-debug",
-            "displayName": "GCC (Debug)",
-            "configurePreset": "gcc",
-            "inherits": "build-debug"
-        }
-    ],
-    "testPresets": [
-        {
-            "name": "test-base",
-            "hidden": true,
-            "output": {
-                "outputOnFailure": true,
-                "verbosity": "default"
-            },
-            "execution": {
-                "noTestsAction": "error",
-                "stopOnFailure": false
-            }
+            "configuration": "Release"
         },
         {
             "name": "msvc-release",
-            "displayName": "MSVC Tests (Release)",
+            "displayName": "MSVC x86-64 Release",
             "configurePreset": "msvc",
-            "inherits": "test-base",
             "configuration": "Release"
-        },
-        {
-            "name": "msvc-debug",
-            "displayName": "MSVC Tests (Debug)",
-            "configurePreset": "msvc",
-            "inherits": "test-base",
-            "configuration": "Debug"
-        },
-        {
-            "name": "clang-release",
-            "displayName": "Clang Tests (Release)",
-            "configurePreset": "clang",
-            "inherits": "test-base",
-            "configuration": "Release"
-        },
-        {
-            "name": "clang-debug",
-            "displayName": "Clang Tests (Debug)",
-            "configurePreset": "clang",
-            "inherits": "test-base",
-            "configuration": "Debug"
-        },
-        {
-            "name": "gcc-release",
-            "displayName": "GCC Tests (Release)",
-            "configurePreset": "gcc",
-            "inherits": "test-base",
-            "configuration": "Release"
-        },
-        {
-            "name": "gcc-debug",
-            "displayName": "GCC Tests (Debug)",
-            "configurePreset": "gcc",
-            "inherits": "test-base",
-            "configuration": "Debug"
         }
     ],
     "packagePresets": [
         {
-            "name": "msvc-package",
-            "displayName": "MSVC Package",
-            "configurePreset": "msvc",
-            "configurations": [
-                "Release"
-            ],
-            "generators": [
-                "ZIP"
-            ]
-        },
-        {
-            "name": "llvm-mingw-i686-package",
-            "displayName": "LLVM-MinGW Win32 Package",
-            "configurePreset": "llvm-mingw-i686",
-            "configurations": [
-                "Release"
-            ],
-            "generators": [
-                "TXZ"
-            ]
-        },
-        {
             "name": "llvm-mingw-x86_64-package",
-            "displayName": "LLVM-MinGW Win64 Package",
+            "displayName": "LLVM-MinGW Windows x86-64 Package",
             "configurePreset": "llvm-mingw-x86_64",
-            "configurations": [
-                "Release"
-            ],
-            "generators": [
-                "TXZ"
-            ]
+            "configurations": ["Release"],
+            "generators": ["TXZ"]
         },
         {
-            "name": "llvm-mingw-aarch64-package",
-            "displayName": "LLVM-MinGW WinARM64 Package",
-            "configurePreset": "llvm-mingw-aarch64",
-            "configurations": [
-                "Release"
-            ],
-            "generators": [
-                "TXZ"
-            ]
-        },
-        {
-            "name": "clang-package",
-            "displayName": "Clang Package",
-            "configurePreset": "clang",
-            "configurations": [
-                "Release"
-            ],
-            "generators": [
-                "TGZ"
-            ]
-        },
-        {
-            "name": "gcc-package",
-            "displayName": "GCC Package",
-            "configurePreset": "gcc",
-            "configurations": [
-                "Release"
-            ],
-            "generators": [
-                "TGZ"
-            ]
+            "name": "msvc-package",
+            "displayName": "MSVC Windows x86-64 Package",
+            "configurePreset": "msvc",
+            "configurations": ["Release"],
+            "generators": ["ZIP"]
         }
     ],
     "workflowPresets": [
         {
-            "name": "msvc-full",
-            "displayName": "MSVC Complete Pipeline",
-            "description": "Configure, build, test, and package with MSVC",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "msvc"
-                },
-                {
-                    "type": "build",
-                    "name": "msvc-release"
-                },
-                {
-                    "type": "test",
-                    "name": "msvc-release"
-                },
-                {
-                    "type": "package",
-                    "name": "msvc-package"
-                }
-            ]
-        },
-        {
-            "name": "llvm-mingw-i686-full",
-            "displayName": "LLVM-MinGW Win32 Pipeline",
-            "description": "Configure, build, and package for Windows 32-bit (no test — cross-compiled binaries cannot run on the Linux host)",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "llvm-mingw-i686"
-                },
-                {
-                    "type": "build",
-                    "name": "llvm-mingw-i686"
-                },
-                {
-                    "type": "package",
-                    "name": "llvm-mingw-i686-package"
-                }
-            ]
-        },
-        {
             "name": "llvm-mingw-x86_64-full",
-            "displayName": "LLVM-MinGW Win64 Pipeline",
-            "description": "Configure, build, and package for Windows 64-bit (no test — cross-compiled)",
+            "displayName": "LLVM-MinGW Windows x86-64 Pipeline",
+            "description": "Configure, build, and package Windows x86-64 version.dll on Linux",
             "steps": [
-                {
-                    "type": "configure",
-                    "name": "llvm-mingw-x86_64"
-                },
-                {
-                    "type": "build",
-                    "name": "llvm-mingw-x86_64"
-                },
-                {
-                    "type": "package",
-                    "name": "llvm-mingw-x86_64-package"
-                }
+                {"type": "configure", "name": "llvm-mingw-x86_64"},
+                {"type": "build", "name": "llvm-mingw-x86_64"},
+                {"type": "package", "name": "llvm-mingw-x86_64-package"}
             ]
         },
         {
-            "name": "llvm-mingw-aarch64-full",
-            "displayName": "LLVM-MinGW WinARM64 Pipeline",
-            "description": "Configure, build, and package for Windows ARM64 (no test — cross-compiled)",
+            "name": "msvc-full",
+            "displayName": "MSVC Windows x86-64 Pipeline",
+            "description": "Configure, build, and package Windows x86-64 version.dll on Windows",
             "steps": [
-                {
-                    "type": "configure",
-                    "name": "llvm-mingw-aarch64"
-                },
-                {
-                    "type": "build",
-                    "name": "llvm-mingw-aarch64"
-                },
-                {
-                    "type": "package",
-                    "name": "llvm-mingw-aarch64-package"
-                }
-            ]
-        },
-        {
-            "name": "clang-full",
-            "displayName": "Clang Complete Pipeline",
-            "description": "Configure, build, test, and package with Clang",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "clang"
-                },
-                {
-                    "type": "build",
-                    "name": "clang-release"
-                },
-                {
-                    "type": "test",
-                    "name": "clang-release"
-                },
-                {
-                    "type": "package",
-                    "name": "clang-package"
-                }
-            ]
-        },
-        {
-            "name": "gcc-full",
-            "displayName": "GCC Complete Pipeline",
-            "description": "Configure, build, test, and package with GCC",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "gcc"
-                },
-                {
-                    "type": "build",
-                    "name": "gcc-release"
-                },
-                {
-                    "type": "test",
-                    "name": "gcc-release"
-                },
-                {
-                    "type": "package",
-                    "name": "gcc-package"
-                }
+                {"type": "configure", "name": "msvc"},
+                {"type": "build", "name": "msvc-release"},
+                {"type": "package", "name": "msvc-package"}
             ]
         }
     ]

--- a/readme.md
+++ b/readme.md
@@ -1,263 +1,46 @@
-# cmake_template
+# WeMod Enhancer
 
-<p align="center">
-  <img src=".github/logo.png" alt="cmake_template logo" width="200"/>
-</p>
+Cross-platform build and patch tooling for Wand/WeMod's Windows Electron client.
+The patcher runs on Windows, Linux, or macOS; generated `version.dll` is Windows x86-64 and can be used under Wine/Proton.
 
-<p align="center">
-  <a href="https://github.com/e-gleba/cmake_template/actions/workflows/cmake_multi_platform.yml"><img src="https://img.shields.io/github/actions/workflow/status/e-gleba/cmake_template/cmake_multi_platform.yml?branch=main&style=for-the-badge&labelColor=1C1C1C&logo=github&label=CI" alt="CI"/></a>
-  <a href="https://isocpp.org/"><img src="https://img.shields.io/badge/C%2B%2B-23%2F26-00599C?style=for-the-badge&logo=cplusplus&logoColor=white&labelColor=1C1C1C" alt="C++ Standard"/></a>
-  <a href="https://cmake.org"><img src="https://img.shields.io/badge/CMake-3.31%2B-064F8C?style=for-the-badge&logo=cmake&logoColor=white&labelColor=1C1C1C" alt="CMake"/></a>
-  <a href="https://github.com/e-gleba/cmake_template/blob/main/license.md"><img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge&labelColor=1C1C1C" alt="License"/></a>
-  <a href="https://github.com/e-gleba/cmake_template/stargazers"><img src="https://img.shields.io/github/stars/e-gleba/cmake_template?style=for-the-badge&labelColor=1C1C1C&logo=github&color=F4C542" alt="Stars"/></a>
-  <a href="docs/contributing.md"><img src="https://img.shields.io/badge/Contributing-Guide-4CAF50?style=for-the-badge&labelColor=1C1C1C" alt="Contributing Guide"/></a>
-</p>
+## Requirements
 
-<p align="center">
-  <b>The only CMake template with Android NDK, Linux→Windows cross-compilation, and Gradle Managed Devices — out of the box.</b>
-</p>
+- Python 3.11+
+- CMake 3.31+
+- Ninja
+- Windows: LLVM-MinGW compiler on `PATH`
+- Linux: existing toolchain file downloads LLVM-MinGW automatically
 
-<p align="center">
-  <a href="https://github.com/e-gleba/cmake_template/generate"><img src="https://img.shields.io/badge/Use%20this%20template-%E2%9C%A8%20Generate%20new%20repo-238636?style=for-the-badge&logo=github&labelColor=1C1C1C" alt="Use this template"/></a>
-</p>
+## Build DLL
 
----
-
-Production-ready C++ template for cross-platform projects. Targets C++23/26. Ninja Multi-Config, CPM, clang-tidy, clang-format, pre-commit hooks. Packages with CPack. Tests with doctest — instrumented on Android via Gradle Managed Devices. Zero friction from clone to package on **Linux, Windows, Android, and macOS**.
-
-```bash
-# Desktop — full pipeline in one command
-cmake --workflow --preset=gcc-full
-
-# Android — configure + build for arm64
-cmake --workflow --preset=android-arm64-full
-
-# Linux → Windows ARM64 — cross-compile + package
-cmake --workflow --preset=llvm-mingw-aarch64-full
+```sh
+python3 tools/wemod_enhancer.py build-dll
 ```
 
----
+## Patch
 
-## Why this template?
+Stop Wand/WeMod first, then pass its directory—the directory containing `resources/app.asar`:
 
-Most CMake starters stop at "it builds on my machine." This one ships to production.
-
-| You need | Most templates | This template |
-|---|---|---|
-| **Android NDK** | ❌ Not even mentioned | ✅ 4 presets (arm64, arm32, x64, x86), API 24, `c++_shared`, Prefab |
-| **Android instrumentation tests** | ❌ | ✅ `AndroidJUnitRunner`, Gradle Managed Devices (Pixel 6 ATD), doctest JNI bridge, [#23 native GTest strategy](https://github.com/e-gleba/cmake_template/issues/23) |
-| **Linux → Windows cross-compile** | ❌ | ✅ llvm-mingw toolchain: x86_64, i686, aarch64 |
-| **CMake Presets** | Basic or none | ✅ 10+ configure presets, 15+ build presets, workflow presets, schema v10 |
-| **Packaging** | ❌ | ✅ CPack: tar.gz, zip, txz per platform |
-| **Reproducible CI** | Manual Docker | ✅ Docker images + GitHub Actions matrix |
-| **Code quality** | Maybe clang-format | ✅ clang-tidy, clang-format, `.cmake-format.yaml`, pre-commit hooks, `.editorconfig` |
-| **C++ Standard** | 17 | ✅ **23 / 26** |
-
-### Unique capabilities
-
-- **Android NDK out of the box** — not just a toolchain file. A full Gradle project with `externalNativeBuild`, `prefab = true`, managed virtual devices, and `connectedCheck` test harness. Builds `.so` or `.aar`. See `android-project/`.
-- **Cross-compile from Linux to Windows** — llvm-mingw toolchain included in `cmake/toolchains/`. Build `.exe` binaries for x86_64, i686, and aarch64 Windows — no Windows machine needed.
-- **One-command workflows** — `cmake --workflow --preset=gcc-full` runs configure → build → test → package. No glue scripts.
-- **Professional CMake architecture** — `CMAKE_CURRENT_LIST_DIR` everywhere (safe for `add_subdirectory`/`FetchContent`), cross-compilation-aware `CMAKE_FIND_ROOT_PATH`, build-type-safe flag management.
-- **Honest roadmap** — every missing feature is a tracked issue, not a hidden gap. See [open issues](https://github.com/e-gleba/cmake_template/issues).
-
----
-
-## Quick Start
-
-### 1. Create your repo from this template
-
-<p align="center">
-  <a href="https://github.com/e-gleba/cmake_template/generate"><b>🎯 Click here: Use this template → Create new repository</b></a>
-</p>
-
-Then clone your new repo:
-
-```bash
-git clone https://github.com/YOUR_USER/YOUR_PROJECT
-cd YOUR_PROJECT
+```sh
+python3 tools/wemod_enhancer.py patch --install-dir "/path/to/Wand"
 ```
 
-### 2. Build and test (desktop)
+Use a prebuilt DLL:
 
-```bash
-# GCC — full pipeline
-cmake --workflow --preset=gcc-full
-
-# Or step by step:
-cmake --preset=gcc
-cmake --build --preset=gcc-release
-ctest --preset=gcc-release
-
-# Clang
-cmake --workflow --preset=clang-full
-
-# MSVC (Windows only)
-cmake --workflow --preset=msvc-full
+```sh
+python3 tools/wemod_enhancer.py patch --install-dir "/path/to/Wand" --version-dll ./version.dll
 ```
 
-### 3. Cross-compile for Android
+For Wine/Proton, pass the Windows application directory inside the prefix, for example:
 
-```bash
-# Requires: ANDROID_NDK_HOME or ANDROID_HOME set
-cmake --preset=android-arm64
-cmake --build --preset=android-arm64
-
-# Run instrumented tests on device/emulator
-cd android-project
-./gradlew pixel_6_aosp_atd_30DebugAndroidTest
-./gradlew connectedCheck
+```sh
+python3 tools/wemod_enhancer.py patch --install-dir "$STEAMLIBRARY/steamapps/compatdata/ID/pfx/drive_c/users/steamuser/AppData/Local/Wand"
 ```
 
-### 4. Cross-compile for Windows (from Linux)
+Restore:
 
-```bash
-# Requires: llvm-mingw installed
-cmake --workflow --preset=llvm-mingw-x86_64-full
-# → build/llvm-mingw-x86_64/package/cxx_project-*.zip
+```sh
+python3 tools/wemod_enhancer.py restore --install-dir "/path/to/Wand"
 ```
 
----
-
-## Platform Matrix
-
-| Platform | Preset | Generator | Test runner | Package |
-|---|---|---|---|---|
-| **Linux (native)** | `gcc`, `clang` | Ninja Multi-Config | `ctest` | `.tar.gz` |
-| **Windows (native)** | `msvc` | Visual Studio 17 2022 | `ctest` | `.zip` |
-| **Windows (cross)** | `llvm-mingw-x86_64`, `llvm-mingw-i686`, `llvm-mingw-aarch64` | Ninja Multi-Config | — (cross-compiled) | `.tar.xz` |
-| **Android arm64** | `android-arm64` | Ninja Multi-Config | `gradlew connectedCheck` | — |
-| **Android arm32** | `android-arm32` | Ninja Multi-Config | `gradlew connectedCheck` | — |
-| **Android x64** | `android-x64` | Ninja Multi-Config | `gradlew connectedCheck` | — |
-| **Android x86** | `android-x86` | Ninja Multi-Config | `gradlew connectedCheck` | — |
-| **macOS** | `clang` (native) | Ninja Multi-Config | `ctest` | `.tar.gz` |
-| **iOS / macOS Xcode** | [planned #20](https://github.com/e-gleba/cmake_template/issues/20) | Xcode | `xctest` / `xcodebuild test` | — |
-| **WebAssembly** | [planned #2](https://github.com/e-gleba/cmake_template/issues/2) | Emscripten | — | — |
-
----
-
-## Comparison: Competitive Landscape
-
-| Feature | **cmake_template** | [cpp-best-practices](https://github.com/cpp-best-practices/cmake_template) | [modern-cpp-template](https://github.com/filipdutescu/modern-cpp-template) | [cmake-init](https://github.com/cginternals/cmake-init) |
-|---|---|---|---|---|
-| **C++ Standard** | **23 / 26** | 17 / 20 | 17 | 11+ |
-| **CMake Presets** | ✅ 10+ with workflows | ❌ | ❌ | ❌ |
-| **Android NDK** | ✅ 4 ABI | ❌ | ❌ | ❌ |
-| **Android instrumented tests** | ✅ GMD + doctest JNI | ❌ | ❌ | ❌ |
-| **Linux → Windows cross** | ✅ llvm-mingw (3 arch) | ❌ | ❌ | ❌ |
-| **WebAssembly** | ❌ [#2](https://github.com/e-gleba/cmake_template/issues/2) | ✅ + Pages deploy | ❌ | ❌ |
-| **Docker / CI** | ✅ + Actions matrix | ✅ Docker + Actions | ✅ GitHub Actions | ✅ |
-| **CPack packaging** | ✅ tar.gz / zip / txz | ❌ | ❌ | ❌ |
-| **Sanitizers** | ❌ [#9](https://github.com/e-gleba/cmake_template/issues/9) | ✅ ASan/UBSan | ✅ | ❌ |
-| **Fuzz testing** | ❌ | ✅ libFuzzer | ❌ | ❌ |
-| **Code coverage** | ❌ [#10](https://github.com/e-gleba/cmake_template/issues/10) | ✅ codecov | ✅ codecov | ❌ |
-| **macOS/iOS (Xcode)** | ❌ [#20](https://github.com/e-gleba/cmake_template/issues/20) | Limited | ❌ | ❌ |
-| **vcpkg** | ❌ [#3](https://github.com/e-gleba/cmake_template/issues/3) | ❌ | ❌ | ❌ |
-| **GitHub Stars** | ⭐ *you are here* | 1,700+ | 1,900+ | 900+ |
-| **Age** | ~1 year | 3 years | 5 years | 11 years |
-| **License** | MIT | Unlicense | Unlicense | MIT |
-
-> **Honest assessment:** This template leads in cross-compilation engineering (Android NDK, Linux→Win, Presets, CPack). It trails in sanitizers, fuzz testing, and code coverage — all actively tracked in the [roadmap](https://github.com/e-gleba/cmake_template/issues). It does not include Qt, OpenGL, or JUCE scaffolding — those are well covered by specialized templates.
-
----
-
-## Project Structure
-
-```
-.
-├── CMakeLists.txt           # Root: project(), CPM, code quality, CTest, CPack
-├── CMakePresets.json        # 10+ configure, 15+ build, workflow presets
-├── cmake/
-│   ├── toolchains/          # llvm-mingw.cmake, future ios.cmake
-│   ├── code_quality/        # clang-tidy, clang-format, cpplint configs
-│   └── description/         # package_description.cmake
-├── src/                     # Library sources
-│   └── CMakeLists.txt
-├── tests/                   # doctest-based tests
-│   ├── CMakeLists.txt       # Shared lib on Android, executable on desktop
-│   ├── doctest_android_jni.cpp  # JNI bridge for Android instrumentation
-│   └── doctest_example.cpp
-├── android-project/         # Gradle project with AGP, GMD, AndroidJUnitRunner
-│   ├── app/
-│   │   ├── build.gradle     # externalNativeBuild → ../../CMakeLists.txt
-│   │   └── src/
-│   │       ├── main/        # NativeActivity entry point
-│   │       └── androidTest/ # Instrumented test wrappers
-│   ├── build.gradle
-│   └── settings.gradle
-├── docker/                  # Dockerfiles for CI reproducibility
-├── scripts/                 # Build helpers
-├── docs/                    # Architecture, presets, Docker guides
-└── tools/                   # IWYU mappings, code quality configs
-```
-
----
-
-## Documentation
-
-| Document | What it covers |
-|---|---|
-| [Presets & Platforms](docs/presets.md) | All CMake presets, platform support, cross-compilation details |
-| [Architecture](docs/architecture.md) | CMake design decisions, directory structure, `PROJECT_IS_TOP_LEVEL` pattern |
-| [Docker Guide](docs/docker.md) | Docker images for CI, local reproducible builds |
-| [Contributing](docs/contributing.md) | How to contribute, code style, pre-commit setup |
-| [References](docs/references.md) | Professional CMake, modern CMake, toolchain references |
-| [Issue: Android native testing strategy](https://github.com/e-gleba/cmake_template/issues/23) | GTest vs doctest, Activity lifecycle, XCTest, CI/CD — research-backed |
-
----
-
-## Consulting
-
-I help teams reduce C++ build friction and ship cross-platform products faster.
-
-**Services:**
-- CMake architecture audits and modernisation
-- Android NDK toolchain setup and Gradle integration
-- CI/CD pipeline design for C++ (GitHub Actions, GitLab CI, Docker)
-- Cross-compilation pipelines (Linux→Windows, Linux→Android, macOS→iOS)
-- CPack packaging and distribution
-- Team onboarding workshops
-
-**Why work with me:**
-- This template is the public portfolio — it demonstrates real engineering depth in CMake, NDK, cross-compilation, and CI
-- I focus exclusively on **build engineering** — not general software consulting
-- Every engagement starts with a concrete deliverable, not a roadmap document
-
-<p align="center">
-
-| | |
-|---|---|
-| 🌐 **Website** | [e-gleba.github.io](https://e-gleba.github.io) |
-| 📧 **Email** | [i@egleba.ru](mailto:i@egleba.ru) — fastest response |
-| 💬 **Discussions** | [GitHub Discussions](https://github.com/e-gleba/cmake_template/discussions) |
-| 💼 **Rate** | Up to $150/hr depending on scope |
-| 📍 **Location** | Remote-first, worldwide |
-
-</p>
-
----
-
-## Roadmap
-
-All planned features are tracked as GitHub issues with the `enhancement` label.
-
-| Priority | Issue | Feature |
-|---|---|---|
-| 🔴 P0 | [#20](https://github.com/e-gleba/cmake_template/issues/20) | macOS/iOS Xcode presets + XCTest |
-| 🔴 P0 | [#9](https://github.com/e-gleba/cmake_template/issues/9) | Sanitizers (ASan/UBSan/TSan) |
-| 🟡 P1 | [#10](https://github.com/e-gleba/cmake_template/issues/10) | Code coverage (codecov/CodeQL) |
-| 🟡 P1 | [#2](https://github.com/e-gleba/cmake_template/issues/2) | WebAssembly (Emscripten) |
-| 🟡 P1 | [#3](https://github.com/e-gleba/cmake_template/issues/3) | vcpkg compatibility |
-| 🟢 P2 | [#5](https://github.com/e-gleba/cmake_template/issues/5) | C++20 modules |
-| 🟢 P2 | [#11](https://github.com/e-gleba/cmake_template/issues/11) | Steam Runtime / Steam Deck |
-| 🟢 P2 | [#8](https://github.com/e-gleba/cmake_template/issues/8) | Prebuilt / air-gapped dependency mode |
-
-[View all issues →](https://github.com/e-gleba/cmake_template/issues)
-
----
-
-## License
-
-MIT — see [license.md](license.md).
-
-This is not a "source available" or dual-licensed project. Use it for anything — commercial products, internal tools, or as a base for your own template. Attribution appreciated but not required.
+Backups are created before modification. Client updates may change minified JavaScript; the patcher fails closed when exact targets cannot be found.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,76 +1,14 @@
+add_library(version SHARED library.c fuses.c library.def)
+set_target_properties(version PROPERTIES PREFIX "" OUTPUT_NAME "version")
+target_compile_features(version PRIVATE c_std_11)
+
+if(MSVC)
+    set_property(TARGET version PROPERTY
+                 MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else()
+    target_link_options(version PRIVATE -static)
+endif()
+
 include(GNUInstallDirs)
-
-add_executable(cli_app main.cpp)
-target_compile_features(cli_app PRIVATE cxx_std_23)
-target_link_libraries(cli_app PRIVATE warnings)
-
-install(TARGETS cli_app RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                                COMPONENT runtime
-)
-
-if(NOT TARGET SDL3::SDL3-shared)
-    return()
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-    add_library(sdl_app SHARED sdl_main.cpp)
-else()
-    add_executable(sdl_app sdl_main.cpp)
-endif()
-
-target_compile_features(sdl_app PRIVATE cxx_std_23)
-target_link_libraries(
-    sdl_app PRIVATE SDL3::SDL3-shared Microsoft.GSL::GSL warnings
-)
-
-if(TARGET Tracy::TracyClient)
-    if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-        add_library(tracy_sandbox SHARED tracy_sandbox.cpp)
-    else()
-        add_executable(tracy_sandbox tracy_sandbox.cpp)
-    endif()
-
-    target_compile_features(tracy_sandbox PRIVATE cxx_std_23)
-    target_link_libraries(
-        tracy_sandbox PRIVATE SDL3::SDL3-shared Tracy::TracyClient
-                              Microsoft.GSL::GSL warnings
-    )
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-    return()
-endif()
-
-# ── RPATH: find libSDL3.so at runtime after install ──
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin|iOS")
-    set_target_properties(
-        sdl_app
-        PROPERTIES INSTALL_RPATH "@executable_path/../${CMAKE_INSTALL_LIBDIR}"
-                   MACOSX_RPATH ON
-    )
-else()
-    set_target_properties(
-        sdl_app PROPERTIES INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
-                           BUILD_RPATH_USE_ORIGIN ON
-    )
-endif()
-
-install(TARGETS sdl_app RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                                COMPONENT runtime
-)
-
-# ── Windows: stage DLLs next to .exe for build-tree runs ──
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.21" AND CMAKE_SYSTEM_NAME STREQUAL
-                                                  "Windows"
-)
-    add_custom_command(
-        TARGET sdl_app
-        POST_BUILD
-        COMMAND
-            ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:sdl_app>
-            $<TARGET_RUNTIME_DLLS:sdl_app>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-add_subdirectory(unity_build)
+install(TARGETS version RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+                        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/src/fuses.c
+++ b/src/fuses.c
@@ -1,0 +1,49 @@
+#include <windows.h>
+
+#define SENTINEL_LENGTH 32
+#define FUSE_INTEGRITY 4
+#define REMOVED 'r'
+#define ALIGN8(p, m) ((((ULONG_PTR)(p) + 7) & ~(ULONG_PTR)7) + ((m) * 8))
+
+#if defined(_WIN64)
+#define S1 0x6E64474B70374C64ULL
+#define S2 0x6262503639377A4EULL
+#define S3 0x58486D4B4E57516AULL
+#define S4 0x5873743942615A42ULL
+#endif
+
+typedef struct {
+    char sentinel[SENTINEL_LENGTH];
+    unsigned char version;
+    unsigned char wire_length;
+    unsigned char fuses[];
+} FuseWire;
+
+static FuseWire *find_wire(int offset) {
+    char *base = (char *)GetModuleHandleA(NULL);
+    if (!base) return NULL;
+    IMAGE_DOS_HEADER *dos = (IMAGE_DOS_HEADER *)base;
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE) return NULL;
+    IMAGE_NT_HEADERS *nt = (IMAGE_NT_HEADERS *)(base + dos->e_lfanew);
+    if (nt->Signature != IMAGE_NT_SIGNATURE) return NULL;
+#if defined(_WIN64)
+    DWORD64 *start = (DWORD64 *)(ALIGN8(base, 1) + offset);
+    DWORD64 *end = (DWORD64 *)(ALIGN8(base + nt->OptionalHeader.SizeOfImage - SENTINEL_LENGTH, -1) - offset);
+    for (DWORD64 *p = start; p < end; ++p)
+        if (p[0] == S1 && p[1] == S2 && p[2] == S3 && p[3] == S4) return (FuseWire *)p;
+#endif
+    return NULL;
+}
+
+BOOL disable_asar_integrity(void) {
+    FuseWire *wire = find_wire(0);
+    if (!wire) wire = find_wire(4);
+    if (!wire || wire->version != 1 || wire->wire_length < 5) return FALSE;
+    unsigned char *fuse = &wire->fuses[FUSE_INTEGRITY];
+    if (*fuse == REMOVED) return TRUE;
+    DWORD old;
+    if (!VirtualProtect(fuse, 1, PAGE_READWRITE, &old)) return FALSE;
+    *fuse = REMOVED;
+    VirtualProtect(fuse, 1, old, &old);
+    return TRUE;
+}

--- a/src/library.c
+++ b/src/library.c
@@ -13,10 +13,10 @@ static HMODULE original_version;
  X(GetFileVersionInfoSizeExW,DWORD,0,(DWORD a,LPCWSTR b,LPDWORD c),(a,b,c)) \
  X(GetFileVersionInfoSizeW,DWORD,0,(LPCWSTR a,LPDWORD b),(a,b)) \
  X(GetFileVersionInfoW,BOOL,FALSE,(LPCWSTR a,DWORD b,DWORD c,LPVOID d),(a,b,c,d)) \
- X(VerFindFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPSTR e,PUINT f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerFindFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPWSTR e,PUINT f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerInstallFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPCSTR e,LPCSTR f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerInstallFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPCWSTR e,LPCWSTR f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerFindFileA,DWORD,0,(DWORD a,LPSTR b,LPSTR c,LPSTR d,LPSTR e,PUINT f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerFindFileW,DWORD,0,(DWORD a,LPWSTR b,LPWSTR c,LPWSTR d,LPWSTR e,PUINT f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileA,DWORD,0,(DWORD a,LPSTR b,LPSTR c,LPSTR d,LPSTR e,LPSTR f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileW,DWORD,0,(DWORD a,LPWSTR b,LPWSTR c,LPWSTR d,LPWSTR e,LPWSTR f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
  X(VerLanguageNameA,DWORD,0,(DWORD a,LPSTR b,DWORD c),(a,b,c)) \
  X(VerLanguageNameW,DWORD,0,(DWORD a,LPWSTR b,DWORD c),(a,b,c)) \
  X(VerQueryValueA,BOOL,FALSE,(LPCVOID a,LPCSTR b,LPVOID *c,PUINT d),(a,b,c,d)) \

--- a/src/library.c
+++ b/src/library.c
@@ -1,0 +1,53 @@
+#include <windows.h>
+#include <winver.h>
+
+extern BOOL disable_asar_integrity(void);
+static HMODULE original_version;
+
+#define VERSION_EXPORTS(X) \
+ X(GetFileVersionInfoA,BOOL,FALSE,(LPCSTR a,DWORD b,DWORD c,LPVOID d),(a,b,c,d)) \
+ X(GetFileVersionInfoExA,BOOL,FALSE,(DWORD a,LPCSTR b,DWORD c,DWORD d,LPVOID e),(a,b,c,d,e)) \
+ X(GetFileVersionInfoExW,BOOL,FALSE,(DWORD a,LPCWSTR b,DWORD c,DWORD d,LPVOID e),(a,b,c,d,e)) \
+ X(GetFileVersionInfoSizeA,DWORD,0,(LPCSTR a,LPDWORD b),(a,b)) \
+ X(GetFileVersionInfoSizeExA,DWORD,0,(DWORD a,LPCSTR b,LPDWORD c),(a,b,c)) \
+ X(GetFileVersionInfoSizeExW,DWORD,0,(DWORD a,LPCWSTR b,LPDWORD c),(a,b,c)) \
+ X(GetFileVersionInfoSizeW,DWORD,0,(LPCWSTR a,LPDWORD b),(a,b)) \
+ X(GetFileVersionInfoW,BOOL,FALSE,(LPCWSTR a,DWORD b,DWORD c,LPVOID d),(a,b,c,d)) \
+ X(VerFindFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPSTR e,PUINT f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerFindFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPWSTR e,PUINT f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPCSTR e,LPCSTR f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPCWSTR e,LPCWSTR f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerLanguageNameA,DWORD,0,(DWORD a,LPSTR b,DWORD c),(a,b,c)) \
+ X(VerLanguageNameW,DWORD,0,(DWORD a,LPWSTR b,DWORD c),(a,b,c)) \
+ X(VerQueryValueA,BOOL,FALSE,(LPCVOID a,LPCSTR b,LPVOID *c,PUINT d),(a,b,c,d)) \
+ X(VerQueryValueW,BOOL,FALSE,(LPCVOID a,LPCWSTR b,LPVOID *c,PUINT d),(a,b,c,d))
+
+#define DECLARE(name,type,fallback,params,args) \
+ typedef type (WINAPI *name##_fn) params; static name##_fn p_##name; \
+ type WINAPI name params { if (!p_##name) { SetLastError(ERROR_PROC_NOT_FOUND); return fallback; } return p_##name args; }
+VERSION_EXPORTS(DECLARE)
+
+BOOL WINAPI GetFileVersionInfoByHandle(void) { SetLastError(ERROR_CALL_NOT_IMPLEMENTED); return FALSE; }
+
+static BOOL load_original(void) {
+    WCHAR path[MAX_PATH];
+    UINT n = GetSystemDirectoryW(path, MAX_PATH);
+    static const WCHAR suffix[] = L"\\version.dll";
+    if (!n || n >= MAX_PATH || n + ARRAYSIZE(suffix) > MAX_PATH) return FALSE;
+    CopyMemory(path + n, suffix, sizeof(suffix));
+    original_version = LoadLibraryW(path);
+    if (!original_version) return FALSE;
+#define LOAD(name,type,fallback,params,args) p_##name = (name##_fn)GetProcAddress(original_version, #name);
+    VERSION_EXPORTS(LOAD)
+    return TRUE;
+}
+
+BOOL WINAPI DllMain(HMODULE module, DWORD reason, LPVOID reserved) {
+    (void)reserved;
+    if (reason == DLL_PROCESS_ATTACH) {
+        DisableThreadLibraryCalls(module);
+        if (!load_original()) return FALSE;
+        disable_asar_integrity();
+    }
+    return TRUE;
+}

--- a/src/library.def
+++ b/src/library.def
@@ -1,0 +1,19 @@
+LIBRARY "VERSION"
+EXPORTS
+GetFileVersionInfoA
+GetFileVersionInfoByHandle
+GetFileVersionInfoExA
+GetFileVersionInfoExW
+GetFileVersionInfoSizeA
+GetFileVersionInfoSizeExA
+GetFileVersionInfoSizeExW
+GetFileVersionInfoSizeW
+GetFileVersionInfoW
+VerFindFileA
+VerFindFileW
+VerInstallFileA
+VerInstallFileW
+VerLanguageNameA
+VerLanguageNameW
+VerQueryValueA
+VerQueryValueW

--- a/tools/wemod_enhancer.py
+++ b/tools/wemod_enhancer.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Build/install version.dll and patch Wand/WeMod Electron app.asar.
+
+Python 3.11+; standard library only. Works on Windows and Linux/macOS hosts.
+ASAR implementation supports regular files and existing app.asar.unpacked files.
+"""
+from __future__ import annotations
+
+import argparse, json, os, re, shutil, struct, subprocess, sys, tempfile
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPORTS = {"GetFileVersionInfoA", "GetFileVersionInfoByHandle", "GetFileVersionInfoExA", "GetFileVersionInfoExW", "GetFileVersionInfoSizeA", "GetFileVersionInfoSizeExA", "GetFileVersionInfoSizeExW", "GetFileVersionInfoSizeW", "GetFileVersionInfoW", "VerFindFileA", "VerFindFileW", "VerInstallFileA", "VerInstallFileW", "VerLanguageNameA", "VerLanguageNameW", "VerQueryValueA", "VerQueryValueW"}
+
+PATCHES = {
+ "activate-pro-account": (r'getUserAccount\(\)\{.*?return\s+this\.#(?P<s>[\w$]+)\.fetch\(\{.*?\}\)\}', lambda m: f'getUserAccount(){{return this.#{m["s"]}.fetch({{endpoint:"/v3/account",method:"GET",name:"/v3/account",collectMetrics:0}}).then(response=>{{response.subscription={{period:"yearly",state:"active"}};return response;}})}}'),
+ "activate-pro-brand": (r'setAccountWandBrandExperience\(\)\{.*?return\s+this\.#(?P<s>[\w$]+)\.post\("/v3/account/brand_experience_wand"\)\}', lambda m: f'setAccountWandBrandExperience(){{return this.#{m["s"]}.post("/v3/account/brand_experience_wand").then(response=>{{response.subscription={{period:"yearly",state:"active"}};return response;}})}}'),
+ "activate-pro-language": (r'setAccountLanguage\((?P<p>[^)]*)\)\{\s*return\s+(?P<e>this\.#\w+\.post\("/v3/account/language",\{[^}]*\}\))\s*;?\s*\}', lambda m: f'setAccountLanguage({m["p"]}){{return ({m["e"]}).then(response=>{{response&&"object"==typeof response&&(response.subscription={{period:"yearly",state:"active"}});return response;}})}}'),
+ "disable-native-pairing": (r'requestRemoteAuthCode\(\)\{return this\.#[\w$]+\.post\("/v3/auth/remote_code"\)\}', 'requestRemoteAuthCode(){return Promise.reject(new Error("wemod-enhancer: native mobile pairing disabled"))}'),
+ "disable-updates": (r'registerHandler\("ACTION_CHECK_FOR_UPDATE".*?\)\)\)\)', 'registerHandler("ACTION_CHECK_FOR_UPDATE",(e=>expectUpdateFeedUrl(e,(e=>null)))'),
+ "devtools-f12": (r'(?P<a>\w+)\.whenReady\(\)\.then\(', lambda m: f'{m["a"]}.on("browser-window-created",((_,w)=>{{try{{w.webContents.on("before-input-event",((_,i)=>{{if("F12"===i.key&&"keyDown"===i.type){{w.webContents.isDevToolsOpened()?w.webContents.closeDevTools():w.webContents.openDevTools({{mode:"detach"}})}}}}))}}catch(e){{}}}})),{m["a"]}.whenReady().then('),
+}
+
+def u32(data: bytes, pos: int) -> int: return struct.unpack_from("<I", data, pos)[0]
+
+def read_asar(path: Path) -> tuple[dict, int]:
+    with path.open("rb") as f:
+        head = f.read(16)
+        if len(head) < 16: raise ValueError("invalid ASAR header")
+        header_size = u32(head, 4)
+        json_size = u32(head, 12)
+        f.seek(16)
+        header = json.loads(f.read(json_size).decode("utf-8"))
+    return header, 8 + header_size
+
+def entries(node: dict, prefix=""):
+    for name, item in node.get("files", {}).items():
+        rel = f"{prefix}/{name}" if prefix else name
+        if "files" in item: yield from entries(item, rel)
+        else: yield rel, item
+
+def safe(root: Path, rel: str) -> Path:
+    parts = PurePosixPath(rel).parts
+    if not parts or any(x in ("", ".", "..") for x in parts): raise ValueError(f"unsafe ASAR path: {rel}")
+    out = root.joinpath(*parts).resolve()
+    if root.resolve() not in (out, *out.parents): raise ValueError(f"unsafe ASAR path: {rel}")
+    return out
+
+def extract_asar(asar: Path, out: Path):
+    header, base = read_asar(asar); unpacked = Path(str(asar) + ".unpacked")
+    with asar.open("rb") as f:
+        for rel, meta in entries(header):
+            dst = safe(out, rel); dst.parent.mkdir(parents=True, exist_ok=True)
+            if meta.get("unpacked"):
+                src = safe(unpacked, rel)
+                if src.exists(): shutil.copy2(src, dst)
+                continue
+            f.seek(base + int(meta.get("offset", 0))); dst.write_bytes(f.read(int(meta.get("size", 0))))
+
+def pickle(payload: bytes) -> bytes:
+    body = struct.pack("<I", len(payload)) + payload
+    body += b"\0" * ((4 - len(body) % 4) % 4)
+    return struct.pack("<I", len(body)) + body
+
+def pack_asar(root: Path, out: Path):
+    files = sorted(p for p in root.rglob("*") if p.is_file())
+    tree = {"files": {}}; offset = 0
+    for p in files:
+        rel = p.relative_to(root).as_posix(); node = tree
+        for part in PurePosixPath(rel).parts[:-1]: node = node["files"].setdefault(part, {"files": {}})
+        size = p.stat().st_size; node["files"][p.name] = {"size": size, "offset": str(offset)}; offset += size
+    raw = json.dumps(tree, separators=(",", ":"), ensure_ascii=False).encode()
+    header = pickle(raw); size = pickle(struct.pack("<I", len(header)))
+    tmp = out.with_suffix(out.suffix + ".tmp")
+    with tmp.open("wb") as f:
+        f.write(size); f.write(header)
+        for p in files: f.write(p.read_bytes())
+    tmp.replace(out)
+
+def patch_bundles(root: Path):
+    candidates = [p for p in root.iterdir() if p.is_file() and (p.name == "index.js" or (p.name.startswith("app-") and p.name.endswith(".bundle.js")))]
+    pending = dict(PATCHES)
+    for path in candidates:
+        text = path.read_text("utf-8"); changed = False
+        for name, (pattern, replacement) in list(pending.items()):
+            matches = list(re.finditer(pattern, text, re.S))
+            if not matches: continue
+            if len(matches) != 1: raise RuntimeError(f"{name}: expected one match, got {len(matches)}")
+            text = re.sub(pattern, replacement, text, count=1, flags=re.S); changed = True; del pending[name]
+            print(f"patched {name}: {path.name}")
+        if changed: path.write_text(text, "utf-8")
+    if pending: raise RuntimeError("unsupported client; missing patches: " + ", ".join(pending))
+
+def pe_x64(path: Path):
+    data = path.read_bytes(); off = u32(data, 0x3c)
+    if data[:2] != b"MZ" or data[off:off+4] != b"PE\0\0" or struct.unpack_from("<H", data, off+4)[0] != 0x8664: raise RuntimeError("version.dll is not PE x86-64")
+
+def find_dll(build: Path) -> Path:
+    found = list(build.rglob("version.dll"))
+    if not found: raise RuntimeError("build completed without version.dll")
+    return found[0]
+
+def build_dll() -> Path:
+    build = ROOT / "build" / "proxy"
+    args = ["cmake", "-S", str(ROOT), "-B", str(build), "-G", "Ninja", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_TESTING=OFF"]
+    if os.name != "nt": args += ["-DCMAKE_TOOLCHAIN_FILE=" + str(ROOT / "cmake/toolchains/llvm_mingw.cmake"), "-DCMAKE_SYSTEM_PROCESSOR=x86_64"]
+    subprocess.run(args, check=True); subprocess.run(["cmake", "--build", str(build), "--config", "Release"], check=True)
+    dll = find_dll(build); pe_x64(dll); return dll
+
+def paths(install: Path):
+    resources = install / "resources"
+    return resources / "app.asar", resources / "app.asar.backup", install / "version.dll", install / "version.dll.wemod-enhancer-backup"
+
+def patch(install: Path, dll: Path | None):
+    asar, backup, target_dll, dll_backup = paths(install)
+    if not asar.is_file(): raise FileNotFoundError(f"missing {asar}")
+    if not backup.exists(): shutil.copy2(asar, backup)
+    else: shutil.copy2(backup, asar)
+    if target_dll.exists() and not dll_backup.exists(): shutil.copy2(target_dll, dll_backup)
+    dll = dll or build_dll(); pe_x64(dll)
+    with tempfile.TemporaryDirectory(prefix="wemod-enhancer-") as tmp:
+        work = Path(tmp); extract_asar(asar, work); patch_bundles(work); pack_asar(work, asar)
+    shutil.copy2(dll, target_dll); print(f"patched {install}")
+
+def restore(install: Path):
+    asar, backup, dll, dll_backup = paths(install)
+    if not backup.exists(): raise FileNotFoundError(f"missing {backup}")
+    shutil.copy2(backup, asar)
+    if dll_backup.exists(): shutil.copy2(dll_backup, dll)
+    elif dll.exists(): dll.unlink()
+    print(f"restored {install}")
+
+def main():
+    p = argparse.ArgumentParser(); sub = p.add_subparsers(dest="cmd", required=True)
+    for name in ("patch", "restore"):
+        q = sub.add_parser(name); q.add_argument("--install-dir", type=Path, required=True)
+        if name == "patch": q.add_argument("--version-dll", type=Path)
+    sub.add_parser("build-dll")
+    a = p.parse_args()
+    if a.cmd == "build-dll": print(build_dll())
+    elif a.cmd == "patch": patch(a.install_dir.resolve(), a.version_dll.resolve() if a.version_dll else None)
+    else: restore(a.install_dir.resolve())
+
+if __name__ == "__main__":
+    try: main()
+    except Exception as e: print(f"error: {e}", file=sys.stderr); raise SystemExit(1)


### PR DESCRIPTION
## Summary
- replace generic C++ sample target with x86-64 Windows `version.dll` proxy
- add portable C source compatible with MSVC and LLVM-MinGW
- add stdlib-only Python patcher for Windows, Wine, and Proton paths
- add ASAR backup, extraction, bundle patching, repacking, DLL installation, and restore
- simplify root CMake metadata and usage documentation

## Scope
Remote web panel is not included because it requires separately built Node/pnpm assets. Core account, update, native pairing, and F12 patches are included.

## Verification
- Python validates generated/supplied DLL as PE x86-64
- patcher requires exactly one regex match per patch and fails closed on unsupported client versions
- original `app.asar` and pre-existing `version.dll` are backed up before modification

## Build
```sh
python3 tools/wemod_enhancer.py build-dll
```

## Patch
```sh
python3 tools/wemod_enhancer.py patch --install-dir /path/to/Wand
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows x64 build of the WeMod Enhancer library.
  * Added command-line tools to build, patch, and restore supported installations.
  * Added automatic backups and safe restoration of modified application files.
  * Added validation and fail-closed behavior when installation files cannot be safely processed.

* **Documentation**
  * Added setup requirements, build instructions, patching examples, restoration guidance, and Wine/Proton notes.

* **Build Improvements**
  * Simplified supported build configurations to Windows MSVC and LLVM-MinGW x64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->