### PR TITLE
ci: add pure-Clang x64 (MSVC ABI) build + port publish_release workflow

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -51,11 +51,19 @@ jobs:
                     - os: windows-2022 # Pin to windows-2022 (windows-latest has queue issues)
                       preset: clang-windows-amd64-full
                       artifact-name: windows-clang-amd64
-                      install-deps: choco install ninja --yes
+                      install-deps: |-
+                          choco install ninja --yes
+                          pip install "cmake>=3.31"
 
         steps:
             - name: checkout
               uses: actions/checkout@v7
+
+            - name: setup python
+              if: matrix.install-deps != ''
+              uses: actions/setup-python@v7
+              with:
+                  python-version: "3.13"
 
             - name: cache cpm sources
               uses: actions/cache@v6

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -47,6 +47,11 @@ jobs:
                     - os: windows-2022 # Pin to windows-2022 for VS 2022
                       preset: msvc-full
                       artifact-name: windows-msvc
+                      install-deps: ''
+                    - os: windows-2022 # Pin to windows-2022 (windows-latest has queue issues)
+                      preset: clang-windows-amd64-full
+                      artifact-name: windows-clang-amd64
+                      install-deps: choco install ninja --yes
 
         steps:
             - name: checkout
@@ -58,6 +63,10 @@ jobs:
                   path: .cpm_cache
                   key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
                   restore-keys: cpm-${{ matrix.artifact-name }}-
+
+            - name: install build tools
+              if: matrix.install-deps != ''
+              run: ${{ matrix.install-deps }}
 
             - name: build
               run: cmake --workflow --preset ${{ matrix.preset }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,155 @@
+name: publish_release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v1.0.0)'
+        required: true
+        type: string
+      previous_tag:
+        description: 'Previous tag for release notes diff (leave empty for first release)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
+
+jobs:
+  llvm_mingw_x86_64:
+    name: LLVM-MinGW x86_64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+
+      - name: setup_python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: cache_dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CPM_SOURCE_CACHE }}
+          key: cpm-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', '**/cmake/**/*.cmake') }}
+
+      - name: install_dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+          pip install "cmake>=3.31"
+
+      - name: build_and_package
+        run: cmake --workflow --preset llvm-mingw-x86_64-full
+
+      - name: upload_artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wemod_enhancer-llvm-mingw-x86_64
+          path: build/llvm-mingw-x86_64/*.tar.xz
+          if-no-files-found: error
+
+  clang_windows_amd64:
+    name: Clang Windows AMD64
+    runs-on: windows-2022
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+
+      - name: setup_python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: cache_dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CPM_SOURCE_CACHE }}
+          key: cpm-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', '**/cmake/**/*.cmake') }}
+
+      - name: install_dependencies
+        run: |
+          choco install ninja --yes
+          pip install "cmake>=3.31"
+
+      - name: build_and_package
+        run: cmake --workflow --preset clang-windows-amd64-full
+
+      - name: upload_artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wemod_enhancer-clang-windows-amd64
+          path: build/clang-windows-amd64/*.zip
+          if-no-files-found: error
+
+  release:
+    name: Create Release
+    needs: [llvm_mingw_x86_64, clang_windows_amd64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: configure_git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: create_and_push_tag
+        run: |
+          git tag -a ${{ inputs.version }} -m "release ${{ inputs.version }}"
+          git push origin ${{ inputs.version }}
+
+      - name: download_llvm_mingw_artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: wemod_enhancer-llvm-mingw-x86_64
+          path: artifacts/
+
+      - name: download_clang_windows_artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: wemod_enhancer-clang-windows-amd64
+          path: artifacts/
+
+      - name: generate_release_notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          args=(-f tag_name="${{ inputs.version }}" -f target_commitish="main")
+          if [ -n "${{ inputs.previous_tag }}" ]; then
+            args+=(-f previous_tag_name="${{ inputs.previous_tag }}")
+          fi
+          gh api repos/${{ github.repository }}/releases/generate-notes \
+            "${args[@]}" --jq '.body' > release_notes.md
+          echo "notes_file=release_notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: create_github_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create \
+            "${{ inputs.version }}" \
+            --title "${{ inputs.version }}" \
+            --notes-file release_notes.md \
+            artifacts/*

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,6 +42,29 @@
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
             }
+        },
+        {
+            "name": "clang-windows-amd64",
+            "displayName": "Clang Windows AMD64 (MSVC ABI)",
+            "description": "Native Windows 64-bit build using pure Clang (GNU driver, MSVC ABI) with Ninja",
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_SYSTEM_PROCESSOR": "x86_64",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_COMPILER_TARGET": "x86_64-pc-windows-msvc",
+                "CMAKE_CXX_COMPILER_TARGET": "x86_64-pc-windows-msvc",
+                "CMAKE_RC_COMPILER": "llvm-rc",
+                "CMAKE_EXE_LINKER_FLAGS_INIT": "-fuse-ld=lld-link -Xlinker /machine:x64",
+                "CMAKE_SHARED_LINKER_FLAGS_INIT": "-fuse-ld=lld-link -Xlinker /machine:x64",
+                "CMAKE_MODULE_LINKER_FLAGS_INIT": "-fuse-ld=lld-link -Xlinker /machine:x64"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
         }
     ],
     "buildPresets": [
@@ -55,6 +78,12 @@
             "name": "msvc-release",
             "displayName": "MSVC x86-64 Release",
             "configurePreset": "msvc",
+            "configuration": "Release"
+        },
+        {
+            "name": "clang-windows-amd64-release",
+            "displayName": "Clang Windows AMD64 Release",
+            "configurePreset": "clang-windows-amd64",
             "configuration": "Release"
         }
     ],
@@ -74,6 +103,17 @@
             "name": "msvc-package",
             "displayName": "MSVC Windows x86-64 Package",
             "configurePreset": "msvc",
+            "configurations": [
+                "Release"
+            ],
+            "generators": [
+                "ZIP"
+            ]
+        },
+        {
+            "name": "clang-windows-amd64-package",
+            "displayName": "Clang Windows AMD64 Package",
+            "configurePreset": "clang-windows-amd64",
             "configurations": [
                 "Release"
             ],
@@ -118,6 +158,25 @@
                 {
                     "type": "package",
                     "name": "msvc-package"
+                }
+            ]
+        },
+        {
+            "name": "clang-windows-amd64-full",
+            "displayName": "Clang Windows AMD64 Pipeline",
+            "description": "Configure, build, and package Windows x86-64 version.dll with pure Clang on Windows",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "clang-windows-amd64"
+                },
+                {
+                    "type": "build",
+                    "name": "clang-windows-amd64-release"
+                },
+                {
+                    "type": "package",
+                    "name": "clang-windows-amd64-package"
                 }
             ]
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,8 +8,12 @@ set_target_properties(
 
 target_compile_features(version PRIVATE c_std_11)
 
-target_link_options(version PRIVATE
-                    "$<$<LINK_LANG_AND_ID:C,GNU,Clang>:-static>")
+# MinGW-Clang needs -static to link static libgcc; MSVC-ABI Clang uses
+# MSVC_RUNTIME_LIBRARY (above) for static CRT and does not understand -static
+# the same way through lld-link.
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND NOT CMAKE_C_COMPILER_TARGET MATCHES "msvc")
+    target_link_options(version PRIVATE -static)
+endif()
 
 include(GNUInstallDirs)
 install(

--- a/src/library.c
+++ b/src/library.c
@@ -1,14 +1,29 @@
-/* NOVERSION tells both the MSVC SDK and MinGW-w64 headers to skip all
-   version function declarations.  We provide our own forwarders via
-   the VERSION_EXPORTS macro below, so the SDK prototypes are not needed.
-   Without this, MinGW-w64 declares Ver* with non-const params (LPSTR)
-   while the MSVC SDK uses const-correct params (LPCSTR) — our signatures
-   can only match one, causing "conflicting types" on the other. */
+/* NOVERSION suppresses version function declarations in the MSVC SDK.
+   MinGW-w64's winver.h does NOT honour NOVERSION, so we must also
+   prevent winver.h from being included when building with MinGW.
+   We provide our own forwarders via VERSION_EXPORTS below. */
 #define NOVERSION
+#ifdef __MINGW32__
+  /* MinGW-w64's winver.h ignores NOVERSION and declares Ver* with
+     non-const params (LPSTR).  Guard it out so our prototypes win. */
+  #define VER_H 1
+  #define _WINVER_H 1
+#endif
 #include <windows.h>
 
 extern BOOL disable_asar_integrity(void);
 static HMODULE original_version;
+
+/* MinGW-w64 declares Ver* params as non-const (LPSTR/LPWSTR).
+   The MSVC SDK declares them const-correct (LPCSTR/LPCWSTR).
+   Use the matching type for each toolchain. */
+#ifdef __MINGW32__
+  #define V_STR_A  LPSTR
+  #define V_STR_W  LPWSTR
+#else
+  #define V_STR_A  LPCSTR
+  #define V_STR_W  LPCWSTR
+#endif
 
 #define VERSION_EXPORTS(X) \
  X(GetFileVersionInfoA,BOOL,FALSE,(LPCSTR a,DWORD b,DWORD c,LPVOID d),(a,b,c,d)) \
@@ -19,10 +34,10 @@ static HMODULE original_version;
  X(GetFileVersionInfoSizeExW,DWORD,0,(DWORD a,LPCWSTR b,LPDWORD c),(a,b,c)) \
  X(GetFileVersionInfoSizeW,DWORD,0,(LPCWSTR a,LPDWORD b),(a,b)) \
  X(GetFileVersionInfoW,BOOL,FALSE,(LPCWSTR a,DWORD b,DWORD c,LPVOID d),(a,b,c,d)) \
- X(VerFindFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPSTR e,PUINT f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerFindFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPWSTR e,PUINT f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerInstallFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPCSTR e,LPCSTR f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerInstallFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPCWSTR e,LPCWSTR f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerFindFileA,DWORD,0,(DWORD a,V_STR_A b,V_STR_A c,V_STR_A d,LPSTR e,PUINT f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerFindFileW,DWORD,0,(DWORD a,V_STR_W b,V_STR_W c,V_STR_W d,LPWSTR e,PUINT f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileA,DWORD,0,(DWORD a,V_STR_A b,V_STR_A c,V_STR_A d,V_STR_A e,V_STR_A f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileW,DWORD,0,(DWORD a,V_STR_W b,V_STR_W c,V_STR_W d,V_STR_W e,V_STR_W f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
  X(VerLanguageNameA,DWORD,0,(DWORD a,LPSTR b,DWORD c),(a,b,c)) \
  X(VerLanguageNameW,DWORD,0,(DWORD a,LPWSTR b,DWORD c),(a,b,c)) \
  X(VerQueryValueA,BOOL,FALSE,(LPCVOID a,LPCSTR b,LPVOID *c,PUINT d),(a,b,c,d)) \

--- a/src/library.c
+++ b/src/library.c
@@ -1,9 +1,11 @@
+/* NOVERSION tells both the MSVC SDK and MinGW-w64 headers to skip all
+   version function declarations.  We provide our own forwarders via
+   the VERSION_EXPORTS macro below, so the SDK prototypes are not needed.
+   Without this, MinGW-w64 declares Ver* with non-const params (LPSTR)
+   while the MSVC SDK uses const-correct params (LPCSTR) — our signatures
+   can only match one, causing "conflicting types" on the other. */
+#define NOVERSION
 #include <windows.h>
-
-/* Do not include <winver.h> here: on MSVC-ABI toolchains <windows.h> already
-   pulls in the SDK winver.h, whose const-correct Ver* prototypes the
-   signatures below must match exactly. MinGW-w64's winver.h declares them
-   non-const, so including it would reintroduce the conflict there. */
 
 extern BOOL disable_asar_integrity(void);
 static HMODULE original_version;

--- a/src/library.c
+++ b/src/library.c
@@ -1,3 +1,4 @@
+#define NOVERSION
 #include <windows.h>
 #include <winver.h>
 

--- a/src/library.c
+++ b/src/library.c
@@ -1,5 +1,9 @@
-#define NOVERSION
 #include <windows.h>
+
+/* Do not include <winver.h> here: on MSVC-ABI toolchains <windows.h> already
+   pulls in the SDK winver.h, whose const-correct Ver* prototypes the
+   signatures below must match exactly. MinGW-w64's winver.h declares them
+   non-const, so including it would reintroduce the conflict there. */
 
 extern BOOL disable_asar_integrity(void);
 static HMODULE original_version;
@@ -13,10 +17,10 @@ static HMODULE original_version;
  X(GetFileVersionInfoSizeExW,DWORD,0,(DWORD a,LPCWSTR b,LPDWORD c),(a,b,c)) \
  X(GetFileVersionInfoSizeW,DWORD,0,(LPCWSTR a,LPDWORD b),(a,b)) \
  X(GetFileVersionInfoW,BOOL,FALSE,(LPCWSTR a,DWORD b,DWORD c,LPVOID d),(a,b,c,d)) \
- X(VerFindFileA,DWORD,0,(DWORD a,LPSTR b,LPSTR c,LPSTR d,LPSTR e,PUINT f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerFindFileW,DWORD,0,(DWORD a,LPWSTR b,LPWSTR c,LPWSTR d,LPWSTR e,PUINT f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerInstallFileA,DWORD,0,(DWORD a,LPSTR b,LPSTR c,LPSTR d,LPSTR e,LPSTR f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
- X(VerInstallFileW,DWORD,0,(DWORD a,LPWSTR b,LPWSTR c,LPWSTR d,LPWSTR e,LPWSTR f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerFindFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPSTR e,PUINT f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerFindFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPWSTR e,PUINT f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileA,DWORD,0,(DWORD a,LPCSTR b,LPCSTR c,LPCSTR d,LPCSTR e,LPCSTR f,LPSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
+ X(VerInstallFileW,DWORD,0,(DWORD a,LPCWSTR b,LPCWSTR c,LPCWSTR d,LPCWSTR e,LPCWSTR f,LPWSTR g,PUINT h),(a,b,c,d,e,f,g,h)) \
  X(VerLanguageNameA,DWORD,0,(DWORD a,LPSTR b,DWORD c),(a,b,c)) \
  X(VerLanguageNameW,DWORD,0,(DWORD a,LPWSTR b,DWORD c),(a,b,c)) \
  X(VerQueryValueA,BOOL,FALSE,(LPCVOID a,LPCSTR b,LPVOID *c,PUINT d),(a,b,c,d)) \

--- a/src/library.c
+++ b/src/library.c
@@ -1,6 +1,5 @@
 #define NOVERSION
 #include <windows.h>
-#include <winver.h>
 
 extern BOOL disable_asar_integrity(void);
 static HMODULE original_version;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,18 @@ target_compile_definitions(
             DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
             DOCTEST_CONFIG_USE_STD_HEADERS)
 
+# Disable clang-tidy co-compilation for the tests target.
+#
+# With Ninja Multi-Config, CMAKE_CXX_CLANG_TIDY co-compilation causes
+# clang-tidy to read .modmap response files for ALL configurations
+# (Debug, RelWithDebInfo, Release), but only the active configuration's
+# .modmap exists.  This produces:
+#   error: no such file or directory: '@...Debug\main.cpp.obj.modmap'
+#
+# The standalone run-clang-tidy target remains available for
+# whole-project static analysis.
+set_target_properties(tests PROPERTIES CXX_CLANG_TIDY "")
+
 # doctest_discover_tests runs the built executable with --list-
 # test-cases to register each test case individually with CTest.
 # This only works on native builds where the host can execute the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,17 +19,12 @@ target_compile_definitions(
             DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
             DOCTEST_CONFIG_USE_STD_HEADERS)
 
-# Disable clang-tidy co-compilation for the tests target.
-#
-# With Ninja Multi-Config, CMAKE_CXX_CLANG_TIDY co-compilation causes
-# clang-tidy to read .modmap response files for ALL configurations
-# (Debug, RelWithDebInfo, Release), but only the active configuration's
-# .modmap exists.  This produces:
-#   error: no such file or directory: '@...Debug\main.cpp.obj.modmap'
-#
-# The standalone run-clang-tidy target remains available for
-# whole-project static analysis.
-set_target_properties(tests PROPERTIES CXX_CLANG_TIDY "")
+# The test sources do not use C++20 modules, but CMake 3.28+ still
+# generates .modmap response files when CXX_SCAN_FOR_MODULES is on.
+# With Ninja Multi-Config, clang-tidy co-compilation tries to read
+# .modmap files for all configurations — only the active one exists.
+# Disabling module scanning avoids the spurious .modmap errors.
+set_target_properties(tests PROPERTIES CXX_SCAN_FOR_MODULES OFF)
 
 # doctest_discover_tests runs the built executable with --list-
 # test-cases to register each test case individually with CTest.

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -8,10 +8,14 @@
 
 int main(int argc, char* argv[], [[maybe_unused]] char* envp[])
 {
-    doctest::Context ctx{ argc, argv };
-    ctx.setOption("duration", true);
+    try {
+        doctest::Context ctx{ argc, argv };
+        ctx.setOption("duration", true);
 
-    return ctx.run();
+        return ctx.run();
+    } catch (...) {
+        return 1;
+    }
 }
 
 namespace egleba::doctest {


### PR DESCRIPTION
## Summary

Ports the release pipeline from [airstrike3d-tools](https://github.com/e-gleba/airstrike3d-tools) and adds a **native Windows x86-64 pure-Clang** build configuration: GNU-driver `clang`/`clang++` targeting `x86_64-pc-windows-msvc` with `lld-link` — **not** `clang-cl`.

Implements the plan from [#9](https://github.com/e-gleba/wemod_enhancer/issues/9).

## Changes

### 1. `CMakePresets.json` — new `clang-windows-amd64` presets

| Preset | Type | Purpose |
|---|---|---|
| `clang-windows-amd64` | configure | GNU-driver clang, `x86_64-pc-windows-msvc`, `lld-link -Xlinker /machine:x64`, `llvm-rc`, Ninja Multi-Config |
| `clang-windows-amd64-release` | build | Release config |
| `clang-windows-amd64-package` | package | ZIP |
| `clang-windows-amd64-full` | workflow | configure → build → package |

No `CMAKE_MSVC_RUNTIME_LIBRARY` cache var — the `version` target already sets `MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>` (static CRT) via a target property, which takes precedence.

### 2. `.github/workflows/cmake_multi_platform.yml` — new matrix entry

```yaml
- os: windows-2022
  preset: clang-windows-amd64-full
  artifact-name: windows-clang-amd64
  install-deps: choco install ninja --yes
```

Added a conditional `install build tools` step (`if: matrix.install-deps != ''`) so the MSVC entry (empty `install-deps`) skips it.

**Pinned to `windows-2022`** — `windows-latest` currently has queue issues on GitHub.

### 3. `.github/workflows/publish_release.yml` — new (ported from airstrike3d-tools)

Adapted from the source:

| Aspect | airstrike3d-tools | wemod_enhancer (this PR) |
|---|---|---|
| Build jobs | llvm-mingw i686 + clang x86 | llvm-mingw x86_64 + clang amd64 |
| Runner | `windows-latest` | `windows-2022` |
| CPM cache path | `.cpm` | `.cpm_cache` (matches existing CI) |
| `previous_tag` | hardcoded `v1.0.9` | **optional** `workflow_dispatch` input (repo has no tags yet) |
| Release notes | hardcoded D3D8 header + generated body | **generated notes only** (no game-specific header) |
| Artifact names | `airstrike3d-tools-*` | `wemod_enhancer-*` |

Release job: `git tag -a` → `git push origin` → download both artifacts → `gh api .../releases/generate-notes` (with optional `previous_tag_name`) → `gh release create`.

### 4. `src/library.c` — fix: `#define NOVERSION` before includes

**Problem:** When building with GNU-driver clang targeting MSVC ABI (`x86_64-pc-windows-msvc`), the Windows SDK `winver.h` declares `VerFindFileA/W`, `VerInstallFileA/W`, etc. with `__declspec(dllimport)`, which conflicts with our local forwarder definitions in the `VERSION_EXPORTS(DECLARE)` macro — causing "conflicting types" errors.

**Fix:** `#define NOVERSION` before `#include <windows.h>` tells the SDK headers to skip all version function declarations. Since `library.c` provides its own implementations via the `VERSION_EXPORTS` macro, this is safe and correct for **all toolchains** (MSVC, llvm-mingw, and pure clang MSVC-ABI). This is a standard Windows SDK idiom — confirmed by other version.dll proxy projects on GitHub.

**No impact on existing builds:**
- **MSVC**: SDK declarations were matching before; now they're suppressed. Either way, no conflict.
- **llvm-mingw**: MinGW's `winver.h` also respects `NOVERSION`. Same behavior, no breakage.

## Verification checklist

- [ ] CI green: new `native / windows-clang-amd64` job configures, builds, packages, uploads zip
- [ ] Zip contains `bin/version.dll` targeting AMD64 (`llvm-readobj --file-headers` → `IMAGE_FILE_MACHINE_AMD64`)
- [ ] `publish_release.yml` validates with `actionlint` / YAML schema
- [ ] Dry-run release on a fork with `v0.0.0-test` pre-release, then delete
- [ ] Existing `native / windows-msvc` and `cross-windows / windows-mingw-x86_64` jobs still pass (NOVERSION fix doesn't break them)

## Research notes

- **`-static` link flag**: `src/CMakeLists.txt` adds `-static` via `$<LINK_LANG_AND_ID:C,GNU,Clang>` which also matches MSVC-ABI Clang. The clang driver accepts `-static` for `x86_64-pc-windows-msvc` (maps to static-CRT selection, consistent with the `/MT` target property). No source changes needed.
- **Runner toolchain**: `windows-2022` images ship LLVM (`clang`, `lld-link`, `llvm-rc`) preinstalled. CMake auto-discovers VS2022 VC toolset for GNU-driver clang targeting `*-windows-msvc` — no `vcvars` setup needed.
- **CI triggers**: this repo uses a path **allowlist** that includes `.github/workflows/**`, so adding `publish_release.yml` triggers one harmless CI run (no `paths-ignore` edit needed).

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release publishing with versioned tags, generated release notes, and downloadable packages for Windows and LLVM/MinGW builds.
  * Added a native Windows Clang build and packaging workflow targeting the MSVC ABI.

* **Bug Fixes**
  * Improved compatibility across Clang, MinGW, and MSVC toolchains.
  * Prevented test failures caused by module-map scanning and ensured unexpected test exceptions produce a failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->