### PR TITLE
feat(install): bundle Python patcher alongside version.dll in CMake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ if(PROJECT_IS_TOP_LEVEL)
     include(GNUInstallDirs)
     find_package(package_description CONFIG REQUIRED)
 
+    # Install the Python patcher CLI next to version.dll so the
+    # install tree is self-contained: users need only Python (no CMake)
+    # to run `python wemod_enhancer.py patch --install-dir ...`.
+    add_subdirectory(tools)
+
     # Append processor to system name so packages for
     # different architectures don't collide (e.g.
     # "Windows-x86_64" vs "Windows-aarch64").

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,20 @@ WeMod Enhancer is a ground-up rewrite that does the same core job with zero runt
 
 ## Quick Start
 
+### From a release package (prebuilt DLL)
+
+Download a release archive, extract it, and run:
+
+```sh
+# version.dll is bundled alongside the script — no CMake needed
+python3 wemod_enhancer.py patch --install-dir "/path/to/wemod_bin"
+
+# Restore originals at any time
+python3 wemod_enhancer.py restore --install-dir "/path/to/wemod_bin"
+```
+
+### From source (build the DLL yourself)
+
 ```sh
 # 1. Stop WeMod, then patch the install directory
 python3 tools/wemod_enhancer.py patch --install-dir "/path/to/wemod_bin"
@@ -62,12 +76,20 @@ python3 tools/wemod_enhancer.py build-dll
 
 Backups are created automatically before modification. If a client update changes minified JavaScript and a required patch no longer matches, the tool **fails closed** — no partial patches are applied.
 
+### Install via CMake (build + install to a directory)
+
+```sh
+cmake --workflow --preset llvm-mingw-x86_64-full
+cmake --install build/llvm-mingw-x86_64 --prefix ./dist
+# dist/bin/ now contains both version.dll and wemod_enhancer.py
+```
+
 ## Requirements
 
 | Tool | Version | Notes |
 |:-----|:--------|:------|
 | **Python** | 3.11+ | Runs the patcher CLI |
-| **CMake** | 3.31+ | Builds the proxy DLL |
+| **CMake** | 3.31+ | Builds the proxy DLL (not needed with prebuilt releases) |
 | **Ninja** | any | Build system generator (required for Clang preset) |
 | **Windows** | — | MSVC (VS 2022) or Clang targeting MSVC ABI (`x86_64-pc-windows-msvc`) |
 | **Linux** | — | LLVM-MinGW toolchain, auto-downloaded by CMake |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,11 +22,3 @@ install(
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" # MSVC import .lib
 )
-
-# Install the Python patcher CLI next to version.dll so the
-# install tree is self-contained: users need only Python (no CMake)
-# to run `python wemod_enhancer.py patch --install-dir ...`.
-install(
-    PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/../tools/wemod_enhancer.py"
-    DESTINATION "${CMAKE_INSTALL_BINDIR}"
-)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,3 +22,11 @@ install(
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" # MSVC import .lib
 )
+
+# Install the Python patcher CLI next to version.dll so the
+# install tree is self-contained: users need only Python (no CMake)
+# to run `python wemod_enhancer.py patch --install-dir ...`.
+install(
+    PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/../tools/wemod_enhancer.py"
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Install the Python patcher CLI next to version.dll so the
+# install tree is self-contained: users need only Python (no CMake)
+# to run `python wemod_enhancer.py patch --install-dir ...`.
+install(
+    PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/wemod_enhancer.py"
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)

--- a/tools/wemod_enhancer.py
+++ b/tools/wemod_enhancer.py
@@ -9,8 +9,8 @@ ROOT = Path(__file__).resolve().parents[1]
 BLOCK_SIZE = 4 * 1024 * 1024
 PATCHES = {
  "activate-pro-account": (r'getUserAccount\(\)\{.*?return\s+this\.#(?P<s>[\w$]+)\.fetch\(\{.*?\}\)\}', lambda m: f'getUserAccount(){{return this.#{m["s"]}.fetch({{endpoint:"/v3/account",method:"GET",name:"/v3/account",collectMetrics:0}}).then(response=>{{response.subscription={{period:"yearly",state:"active"}};return response;}})}}'),
- "activate-pro-language": (r'setAccountLanguage\((?P<p>[^)]*)\)\{\s*return\s+(?P<e>this\.#\w+\.post\("/v3/account/language",\{[^}]*\}))\s*;?\s*\}', lambda m: f'setAccountLanguage({m["p"]}){{return ({m["e"]}).then(response=>{{response&&"object"==typeof response&&(response.subscription={{period:"yearly",state:"active"}});return response;}})}}'),
- "disable-native-pairing": (r'requestRemoteAuthCode\(\)\{return this\#[\w$]+\.post\("/v3/auth/remote_code"\)\}', 'requestRemoteAuthCode(){return Promise.reject(new Error("wemod-enhancer: native mobile pairing disabled"))}'),
+ "activate-pro-language": (r'setAccountLanguage\((?P<p>[^)]*)\)\{\s*return\s+(?P<e>this\.#\w+\.post\("/v3/account/language",\{[^}]*\}\))\s*;?\s*\}', lambda m: f'setAccountLanguage({m["p"]}){{return ({m["e"]}).then(response=>{{response&&"object"==typeof response&&(response.subscription={{period:"yearly",state:"active"}});return response;}})}}'),
+ "disable-native-pairing": (r'requestRemoteAuthCode\(\)\{return this\.#[\w$]+\.post\("/v3/auth/remote_code"\)\}', 'requestRemoteAuthCode(){return Promise.reject(new Error("wemod-enhancer: native mobile pairing disabled"))}'),
  "disable-updates": (r'registerHandler\("ACTION_CHECK_FOR_UPDATE".*?\)\)\)\)', 'registerHandler("ACTION_CHECK_FOR_UPDATE",(e=>expectUpdateFeedUrl(e,(e=>null)))'),
  "devtools-f12": (r'(?P<a>\w+)\.whenReady\(\)\.then\(', lambda m: f'{m["a"]}.on("browser-window-created",((_,w)=>{{try{{w.webContents.on("before-input-event",((_,i)=>{{if("F12"===i.key&&"keyDown"===i.type){{w.webContents.isDevToolsOpened()?w.webContents.closeDevTools():w.webContents.openDevTools({{mode:"detach"}})}}}}))}}catch(e){{}}}})),{m["a"]}.whenReady().then('),
 }

--- a/tools/wemod_enhancer.py
+++ b/tools/wemod_enhancer.py
@@ -123,12 +123,29 @@ def find_dll(build: Path) -> Path:
     if not found: raise RuntimeError("build completed without version.dll")
     return found[0]
 
+def find_bundled_dll() -> Path | None:
+    """Find version.dll next to this script (CMake install layout).
+
+    After `cmake --install` both wemod_enhancer.py and version.dll
+    land in the same directory.  This lets end users run the patcher
+    with just Python — no CMake or compiler needed.
+    """
+    dll = Path(__file__).resolve().parent / "version.dll"
+    return dll if dll.is_file() else None
+
 def build_dll() -> Path:
     build = ROOT / "build" / "proxy"
     args = ["cmake", "-S", str(ROOT), "-B", str(build), "-G", "Ninja", "-DCMAKE_BUILD_TYPE=Release"]
     if os.name != "nt": args += ["-DCMAKE_TOOLCHAIN_FILE=" + str(ROOT / "cmake/toolchains/llvm_mingw.cmake"), "-DCMAKE_SYSTEM_PROCESSOR=x86_64"]
     subprocess.run(args, check=True); subprocess.run(["cmake", "--build", str(build), "--config", "Release"], check=True)
     dll = find_dll(build); pe_x64(dll); return dll
+
+def resolve_dll(explicit: Path | None) -> Path:
+    """Pick version.dll: explicit flag > bundled > build from source."""
+    if explicit: return explicit
+    bundled = find_bundled_dll()
+    if bundled: return bundled
+    return build_dll()
 
 def paths(install: Path):
     resources = install / "resources"
@@ -140,7 +157,7 @@ def patch(install: Path, dll: Path | None):
     if not backup.exists(): shutil.copy2(asar, backup)
     else: shutil.copy2(backup, asar)
     if target_dll.exists() and not dll_backup.exists(): shutil.copy2(target_dll, dll_backup)
-    dll = dll or build_dll(); pe_x64(dll)
+    dll = resolve_dll(dll); pe_x64(dll)
     try:
         with tempfile.TemporaryDirectory(prefix="wemod-enhancer-") as tmp:
             work = Path(tmp); header = extract_asar(asar, work); patch_bundles(work); pack_asar(work, asar, header)

--- a/tools/wemod_enhancer.py
+++ b/tools/wemod_enhancer.py
@@ -9,8 +9,8 @@ ROOT = Path(__file__).resolve().parents[1]
 BLOCK_SIZE = 4 * 1024 * 1024
 PATCHES = {
  "activate-pro-account": (r'getUserAccount\(\)\{.*?return\s+this\.#(?P<s>[\w$]+)\.fetch\(\{.*?\}\)\}', lambda m: f'getUserAccount(){{return this.#{m["s"]}.fetch({{endpoint:"/v3/account",method:"GET",name:"/v3/account",collectMetrics:0}}).then(response=>{{response.subscription={{period:"yearly",state:"active"}};return response;}})}}'),
- "activate-pro-language": (r'setAccountLanguage\((?P<p>[^)]*)\)\{\s*return\s+(?P<e>this\.#\w+\.post\("/v3/account/language",\{[^}]*\}\))\s*;?\s*\}', lambda m: f'setAccountLanguage({m["p"]}){{return ({m["e"]}).then(response=>{{response&&"object"==typeof response&&(response.subscription={{period:"yearly",state:"active"}});return response;}})}}'),
- "disable-native-pairing": (r'requestRemoteAuthCode\(\)\{return this\.#[\w$]+\.post\("/v3/auth/remote_code"\)\}', 'requestRemoteAuthCode(){return Promise.reject(new Error("wemod-enhancer: native mobile pairing disabled"))}'),
+ "activate-pro-language": (r'setAccountLanguage\((?P<p>[^)]*)\)\{\s*return\s+(?P<e>this\.#\w+\.post\("/v3/account/language",\{[^}]*\}))\s*;?\s*\}', lambda m: f'setAccountLanguage({m["p"]}){{return ({m["e"]}).then(response=>{{response&&"object"==typeof response&&(response.subscription={{period:"yearly",state:"active"}});return response;}})}}'),
+ "disable-native-pairing": (r'requestRemoteAuthCode\(\)\{return this\#[\w$]+\.post\("/v3/auth/remote_code"\)\}', 'requestRemoteAuthCode(){return Promise.reject(new Error("wemod-enhancer: native mobile pairing disabled"))}'),
  "disable-updates": (r'registerHandler\("ACTION_CHECK_FOR_UPDATE".*?\)\)\)\)', 'registerHandler("ACTION_CHECK_FOR_UPDATE",(e=>expectUpdateFeedUrl(e,(e=>null)))'),
  "devtools-f12": (r'(?P<a>\w+)\.whenReady\(\)\.then\(', lambda m: f'{m["a"]}.on("browser-window-created",((_,w)=>{{try{{w.webContents.on("before-input-event",((_,i)=>{{if("F12"===i.key&&"keyDown"===i.type){{w.webContents.isDevToolsOpened()?w.webContents.closeDevTools():w.webContents.openDevTools({{mode:"detach"}})}}}}))}}catch(e){{}}}})),{m["a"]}.whenReady().then('),
 }


### PR DESCRIPTION
## What

CMake now installs `tools/wemod_enhancer.py` alongside `version.dll` into `${CMAKE_INSTALL_BINDIR}`, so the install tree is self-contained. Users who download a release package or run `cmake --install` get both files side-by-side — they need only Python to patch WeMod, no CMake or compiler.

## Structure

Each directory manages its own install rules — no cross-directory path hacks:

```
CMakeLists.txt          ← add_subdirectory(tools) after GNUInstallDirs
├── src/CMakeLists.txt  ← installs version.dll (unchanged)
└── tools/CMakeLists.txt← installs wemod_enhancer.py (NEW)
```

`tools/CMakeLists.txt` is a new file that installs the Python script to `${CMAKE_INSTALL_BINDIR}` — the same destination as `version.dll`. It's added via `add_subdirectory(tools)` from the root `CMakeLists.txt`, inside the `if(PROJECT_IS_TOP_LEVEL)` block (after `include(GNUInstallDirs)`, before `include(CPack)`).

## Files changed

### `tools/CMakeLists.txt` (NEW — 7 lines)

```cmake
install(
    PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/wemod_enhancer.py"
    DESTINATION "${CMAKE_INSTALL_BINDIR}"
)
```

`PROGRAMS` (not `FILES`) so the script gets executable permissions on Unix.

### `CMakeLists.txt` (+5 lines)

Added `add_subdirectory(tools)` inside `if(PROJECT_IS_TOP_LEVEL)`, after `include(GNUInstallDirs)` and before `include(CPack)`.

### `tools/wemod_enhancer.py` (+20 lines, -1 line)

Two new functions, one call-site change:

- **`find_bundled_dll()`** — finds `version.dll` next to the script itself via `Path(__file__).resolve().parent`. Works for the CMake install layout where both files land in the same `bin/` directory.

- **`resolve_dll(explicit)`** — priority chain:
  1. `--version-dll` flag (explicit override)
  2. Bundled DLL (found by `find_bundled_dll()`) — install/release mode
  3. `build_dll()` from source — developer mode fallback

- **`patch()`** — changed `dll = dll or build_dll()` → `dll = resolve_dll(dll)`

No existing behavior changes. `build_dll()`, `--version-dll`, and `build-dll` subcommand all work exactly as before when no bundled DLL is present.

### `readme.md` (+23 lines, -1 line)

- Added "From a release package (prebuilt DLL)" Quick Start section
- Added "Install via CMake" section showing `cmake --workflow` + `cmake --install`
- Updated Requirements table: CMake notes "(not needed with prebuilt releases)"

## How it works end-to-end

```
Developer builds:
  cmake --workflow --preset llvm-mingw-x86_64-full
  cmake --install build/llvm-mingw-x86_64 --prefix ./dist
  → dist/bin/version.dll + dist/bin/wemod_enhancer.py

End user:
  python3 wemod_enhancer.py patch --install-dir "/path/to/wemod_bin"
  → script finds version.dll next to itself, no CMake needed
```

## Verification checklist

- [ ] `cmake --workflow --preset llvm-mingw-x86_64-full` passes (build + package)
- [ ] `cmake --install build/llvm-mingw-x86_64 --prefix ./dist` produces `dist/bin/version.dll` + `dist/bin/wemod_enhancer.py`
- [ ] `python3 dist/bin/wemod_enhancer.py patch --install-dir ...` works without CMake on the target machine
- [ ] `python3 tools/wemod_enhancer.py build-dll` still works from source tree (developer mode unchanged)