### PR TITLE
Fix workflows: add MSVC to release, proper artifact naming

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -38,19 +38,21 @@ env:
 jobs:
     # ── native builds ───────────────────────────────────────────────────────────
     native:
-        name: native / ${{ matrix.artifact-name }}
+        name: ${{ matrix.artifact-name }}
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - os: windows-2022 # Pin to windows-2022 for VS 2022
+                    - os: windows-2022
                       preset: msvc-full
-                      artifact-name: windows-msvc
+                      artifact-name: windows-msvc-amd64
+                      build-dir: build/msvc
                       install-deps: ''
-                    - os: windows-2022 # Pin to windows-2022 (windows-latest has queue issues)
+                    - os: windows-2022
                       preset: clang-windows-amd64-full
                       artifact-name: windows-clang-amd64
+                      build-dir: build/clang-windows-amd64
                       install-deps: |-
                           choco install ninja --yes
                           pip install "cmake>=3.31"
@@ -79,11 +81,29 @@ jobs:
             - name: build
               run: cmake --workflow --preset ${{ matrix.preset }}
 
+            - name: rename zip artifact
+              if: matrix.artifact-name == 'windows-msvc-amd64' || matrix.artifact-name == 'windows-clang-amd64'
+              shell: pwsh
+              run: |
+                  cd ${{ matrix.build-dir }}
+                  Get-ChildItem *.zip -ErrorAction SilentlyContinue | ForEach-Object {
+                      Rename-Item $_.Name "wemod_enhancer-${{ matrix.artifact-name }}.zip"
+                  }
+
+            - name: rename tgz artifact
+              if: matrix.artifact-name == 'windows-msvc-amd64' || matrix.artifact-name == 'windows-clang-amd64'
+              shell: pwsh
+              run: |
+                  cd ${{ matrix.build-dir }}
+                  Get-ChildItem *.tar.gz -ErrorAction SilentlyContinue | ForEach-Object {
+                      Rename-Item $_.Name "wemod_enhancer-${{ matrix.artifact-name }}.tar.gz"
+                  }
+
             - name: upload zip artifact
               uses: actions/upload-artifact@v7
               with:
                   name: ${{ matrix.artifact-name }}-zip
-                  path: build/**/*.zip
+                  path: ${{ matrix.build-dir }}/*.zip
                   if-no-files-found: ignore
                   compression-level: 0
 
@@ -91,20 +111,21 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: ${{ matrix.artifact-name }}-tgz
-                  path: build/**/*.tar.gz
+                  path: ${{ matrix.build-dir }}/*.tar.gz
                   if-no-files-found: ignore
                   compression-level: 0
 
     # ── cross-compile: Linux → Windows (llvm-mingw) ─────────────────────────────
     cross-windows:
-        name: cross-windows / ${{ matrix.artifact-name }}
+        name: ${{ matrix.artifact-name }}
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
                 include:
                     - preset: llvm-mingw-x86_64-full
-                      artifact-name: windows-mingw-x86_64
+                      artifact-name: windows-llvm-mingw-amd64
+                      build-dir: build/llvm-mingw-x86_64
 
         steps:
             - name: checkout
@@ -131,10 +152,17 @@ jobs:
             - name: build
               run: cmake --workflow --preset ${{ matrix.preset }}
 
+            - name: rename txz artifact
+              run: |
+                  cd ${{ matrix.build-dir }}
+                  for f in *.tar.xz; do
+                    [ -f "$f" ] && mv "$f" "wemod_enhancer-${{ matrix.artifact-name }}.tar.xz"
+                  done
+
             - name: upload txz artifact
               uses: actions/upload-artifact@v7
               with:
                   name: ${{ matrix.artifact-name }}-txz
-                  path: build/**/*.tar.xz
+                  path: ${{ matrix.build-dir }}/*.tar.xz
                   if-no-files-found: ignore
                   compression-level: 0

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -24,8 +24,9 @@ env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
 
 jobs:
+  # ── LLVM-MinGW cross-compile (Linux → Windows) ─────────────────────────────
   llvm_mingw_x86_64:
-    name: LLVM-MinGW x86_64
+    name: windows-llvm-mingw-amd64
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,15 +55,23 @@ jobs:
       - name: build_and_package
         run: cmake --workflow --preset llvm-mingw-x86_64-full
 
+      - name: rename_artifact
+        run: |
+          cd build/llvm-mingw-x86_64
+          for f in *.tar.xz; do
+            mv "$f" "wemod_enhancer-windows-llvm-mingw-amd64.tar.xz"
+          done
+
       - name: upload_artifact
         uses: actions/upload-artifact@v7
         with:
-          name: wemod_enhancer-llvm-mingw-x86_64
+          name: windows-llvm-mingw-amd64
           path: build/llvm-mingw-x86_64/*.tar.xz
           if-no-files-found: error
 
+  # ── Clang Windows AMD64 (MSVC ABI) ─────────────────────────────────────────
   clang_windows_amd64:
-    name: Clang Windows AMD64
+    name: windows-clang-amd64
     runs-on: windows-2022
     permissions:
       contents: read
@@ -90,16 +99,56 @@ jobs:
       - name: build_and_package
         run: cmake --workflow --preset clang-windows-amd64-full
 
+      - name: rename_artifact
+        shell: pwsh
+        run: |
+          cd build/clang-windows-amd64
+          Get-ChildItem *.zip | Rename-Item -NewName "wemod_enhancer-windows-clang-amd64.zip"
+
       - name: upload_artifact
         uses: actions/upload-artifact@v7
         with:
-          name: wemod_enhancer-clang-windows-amd64
+          name: windows-clang-amd64
           path: build/clang-windows-amd64/*.zip
           if-no-files-found: error
 
+  # ── MSVC Windows AMD64 ─────────────────────────────────────────────────────
+  msvc_windows_amd64:
+    name: windows-msvc-amd64
+    runs-on: windows-2022
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+
+      - name: cache_dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CPM_SOURCE_CACHE }}
+          key: cpm-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', '**/cmake/**/*.cmake') }}
+
+      - name: build_and_package
+        run: cmake --workflow --preset msvc-full
+
+      - name: rename_artifact
+        shell: pwsh
+        run: |
+          cd build/msvc
+          Get-ChildItem *.zip | Rename-Item -NewName "wemod_enhancer-windows-msvc-amd64.zip"
+
+      - name: upload_artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-msvc-amd64
+          path: build/msvc/*.zip
+          if-no-files-found: error
+
+  # ── Create GitHub Release ──────────────────────────────────────────────────
   release:
     name: Create Release
-    needs: [llvm_mingw_x86_64, clang_windows_amd64]
+    needs: [llvm_mingw_x86_64, clang_windows_amd64, msvc_windows_amd64]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -122,13 +171,19 @@ jobs:
       - name: download_llvm_mingw_artifact
         uses: actions/download-artifact@v8
         with:
-          name: wemod_enhancer-llvm-mingw-x86_64
+          name: windows-llvm-mingw-amd64
           path: artifacts/
 
       - name: download_clang_windows_artifact
         uses: actions/download-artifact@v8
         with:
-          name: wemod_enhancer-clang-windows-amd64
+          name: windows-clang-amd64
+          path: artifacts/
+
+      - name: download_msvc_windows_artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-msvc-amd64
           path: artifacts/
 
       - name: generate_release_notes


### PR DESCRIPTION
## Summary
- Add MSVC build job to `publish_release.yml` (was missing)
- Standardize artifact naming across all workflows using `platform-compiler-arch` triplet format
- Rename produced archives to include proper triplet names

## Changes

### publish_release.yml
- Added `msvc_windows_amd64` job for MSVC builds
- Renamed all artifacts to use consistent naming:
  - `wemod_enhancer-windows-llvm-mingw-amd64.tar.xz`
  - `wemod_enhancer-windows-clang-amd64.zip`
  - `wemod_enhancer-windows-msvc-amd64.zip`
- Release job now downloads and includes all 3 artifacts

### cmake_multi_platform.yml
- Updated matrix to use consistent `artifact-name` values:
  - `windows-msvc-amd64` (was `windows-msvc`)
  - `windows-clang-amd64` (unchanged)
  - `windows-llvm-mingw-amd64` (was `windows-mingw-x86_64`)
- Added rename steps to produce properly named archives
- Added `build-dir` matrix variable for cleaner paths

## Artifact Naming Convention
```
wemod_enhancer-{platform}-{compiler}-{arch}.{ext}
```

| Platform | Compiler | Arch | Example |
|----------|----------|------|---------|
| windows  | msvc     | amd64 | wemod_enhancer-windows-msvc-amd64.zip |
| windows  | clang    | amd64 | wemod_enhancer-windows-clang-amd64.zip |
| windows  | llvm-mingw | amd64 | wemod_enhancer-windows-llvm-mingw-amd64.tar.xz |