### PR TITLE
chore(deps): CPM 0.43.1, drop unused sol2, renovate config overhaul

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,13 +1,11 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
 
-  extends: [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticPrefixFixDepsChoreOthers",
-    "group:monorepos",
-    "helpers:pinGitHubActionDigests"
-  ],
+  // config:best-practices = config:recommended + docker:pinDigests +
+  // helpers:pinGitHubActionDigests + :configMigration + :pinDevDependencies +
+  // abandonments:recommended + security:minimumReleaseAgeNpm +
+  // :maintainLockFilesWeekly
+  extends: ["config:best-practices"],
 
   // ─── General ──────────────────────────────────────────────────────────────
   timezone: "UTC",
@@ -24,129 +22,93 @@
   vulnerabilityAlerts: {
     enabled: true,
     schedule: ["at any time"],
-    labels: ["dependencies", "security"]
+    labels: ["dependencies", "security"],
   },
 
-  // ─── GitHub Actions ───────────────────────────────────────────────────────
-  // Covers .github/workflows/*.yml — checkout, setup-python, cache,
-  // upload-artifact, download-artifact, etc.
+  // Dependabot owns github-actions updates (see .github/dependabot.yml) —
+  // disable here so the two bots never open duplicate PRs.
   "github-actions": {
-    enabled: true
+    enabled: false,
   },
+
   packageRules: [
-    {
-      description: "Group all GitHub Actions bumps into one PR",
-      matchManagers: ["github-actions"],
-      groupName: "github-actions",
-      labels: ["dependencies", "github-actions"]
-    },
     {
       description: "Auto-merge patch and pin updates after CI passes",
       matchUpdateTypes: ["patch", "pin"],
       automerge: true,
       automergeStrategy: "squash",
-      platformAutomerge: true
-    }
+      platformAutomerge: true,
+    },
+    {
+      description: "Hold Gradle/AGP major upgrades — verify in Android Studio first",
+      matchManagers: ["gradle", "gradle-wrapper"],
+      matchUpdateTypes: ["major"],
+      enabled: false,
+    },
   ],
 
   // ─── CPM (CMake Package Manager) ──────────────────────────────────────────
-  // CPM deps live in cmake/cpm/*.cmake via cpmaddpackage() calls.
-  // Renovate has no native CPM manager, so we use regex customManagers.
-  //
-  // Tracked dependencies:
-  //   cpm          cpm-cmake/CPM.cmake              (version var)
-  //   doctest      doctest/doctest                  (GIT_TAG)
-  //   entt         skypjack/entt                    (GIT_TAG)
-  //   fastgltf     spnda/fastgltf                   (GIT_TAG)
-  //   flecs        SanderMertens/flecs              (GIT_TAG)
-  //   freetype     freetype/freetype                VER-2-14-3 (GIT_TAG)
-  //   glm          g-truc/glm                       (GIT_TAG)
-  //   gsl          microsoft/GSL                    (GIT_TAG)
-  //   imgui        ocornut/imgui                    (VERSION)
-  //   implot       epezent/implot                   (GIT_TAG)
-  //   lua          lua/lua                          (VERSION)
-  //   pybind       pybind/pybind11                  (GIT_TAG)
-  //   safetyhook   cursey/safetyhook                (GIT_TAG)
-  //   sdl3         libsdl-org/SDL                   (GIT_TAG)
-  //   sdl3_mixer   libsdl-org/SDL_mixer             (GIT_TAG)
-  //   shadercross  libsdl-org/shadercross           (GIT_TAG)
-  //   spdlog       gabime/spdlog                    (GIT_TAG)
-  //   stb          nothings/stb                     (GIT_TAG)
-  //   steam_audio  ValveSoftware/steam-audio        (GIT_TAG)
-  //   tinygltf     syoyo/tinygltf                   (GIT_TAG)
-  //   tinyobjloader syoyo/tinyobjloader             (GIT_TAG)
-  //   tracy        wolfpld/tracy                    (GIT_TAG)
-  //   yaml-cpp     jbeder/yaml-cpp                  (GIT_TAG)
+  // No native CPM manager — regex customManagers over cmake/cpm-config.cmake
+  // (CPM itself) and cmake/cpm/*-config.cmake (deps). Both
+  // GIT_REPOSITORY https://github.com/owner/repo and GITHUB_REPOSITORY owner/repo
+  // forms are matched.
   customManagers: [
-    // ── CPM version variable (cpm-config.cmake) ─────────────────────────────
-    // Matches: set(cpm_version "0.42.3")
-    // followed by a FetchContent URL referencing cpm-cmake/CPM.cmake
+    // Matches: set(cpm_version "0.43.1")
     {
       customType: "regex",
-      description: "Update CPM.cmake version variable",
+      description: "CPM.cmake itself (cpm_version variable)",
       managerFilePatterns: ["/(^|/)cpm-config\\.cmake$/"],
       matchStrings: [
-        "set\\(cpm_version\\s+\"(?<currentValue>[^\"]+)\"\\)"
+        "set\\(cpm_version\\s+\"(?<currentValue>[^\"]+)\"\\)",
       ],
       depNameTemplate: "cpm-cmake/CPM.cmake",
       datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^v?(?<version>.+)$"
+      extractVersionTemplate: "^v?(?<version>.+)$",
     },
 
-    // ── CPM packages with GIT_TAG (version tags, not SHAs) ──────────────────
     // Matches: GIT_TAG v1.17.0 / GIT_TAG 1.0.3 / GIT_TAG VER-2-14-3
-    // paired with: GIT_REPOSITORY https://github.com/owner/repo
-    //
-    // Handles both orderings (GIT_TAG before GIT_REPOSITORY and vice versa).
-    // Excludes pure hex SHAs (5-40 chars) — those are handled by the digest manager.
+    // paired with the repository declaration (either order, adjacent lines).
+    // Pure hex SHAs also match here but fail tag lookup harmlessly —
+    // they are handled by the digest manager below.
     {
       customType: "regex",
-      description: "Update CPM deps pinned by GIT_TAG (version tags)",
+      description: "CPM deps pinned by GIT_TAG (version tags)",
       managerFilePatterns: ["/(^|/)cmake/cpm/[^/]+-config\\.cmake$/"],
       matchStrings: [
-        // GIT_TAG before GIT_REPOSITORY
-        "GIT_TAG\\s+(?<currentValue>v?[A-Za-z]*\\d[^\\s\"]*?)\\s+GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
-        // GIT_REPOSITORY before GIT_TAG
-        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentValue>v?[A-Za-z]*\\d[^\\s\"]*?)\\s"
+        "GIT_TAG\\s+(?<currentValue>v?[A-Za-z]*\\d[^\\s\"]*?)\\s+(?:GIT_REPOSITORY\\s+https://github\\.com/|GITHUB_REPOSITORY\\s+)(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
+        "(?:GIT_REPOSITORY\\s+https://github\\.com/|GITHUB_REPOSITORY\\s+)(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentValue>v?[A-Za-z]*\\d[^\\s\"]*?)\\s",
       ],
       datasourceTemplate: "github-tags",
-      extractVersionTemplate: "^(?:v|VER-)?(?<version>.+)$"
+      extractVersionTemplate: "^(?:v|VER-)?(?<version>.+)$",
     },
 
-    // ── CPM packages with VERSION only (implies GIT_TAG v{VERSION}) ─────────
-    // Matches: VERSION 1.92.8  paired with GIT_REPOSITORY
-    // Used by: imgui, lua
+    // Matches: VERSION 1.92.8 paired with the repository declaration
+    // (implies GIT_TAG v{VERSION}). Used by: imgui, lua.
     {
       customType: "regex",
-      description: "Update CPM deps pinned by VERSION field",
+      description: "CPM deps pinned by VERSION field",
       managerFilePatterns: ["/(^|/)cmake/cpm/[^/]+-config\\.cmake$/"],
       matchStrings: [
-        // VERSION before GIT_REPOSITORY
-        "VERSION\\s+(?<currentValue>\\d[^\\s\"]*?)\\s+GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
-        // GIT_REPOSITORY before VERSION
-        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+VERSION\\s+(?<currentValue>\\d[^\\s\"]*?)\\s"
+        "VERSION\\s+(?<currentValue>\\d[^\\s\"]*?)\\s+(?:GIT_REPOSITORY\\s+https://github\\.com/|GITHUB_REPOSITORY\\s+)(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
+        "(?:GIT_REPOSITORY\\s+https://github\\.com/|GITHUB_REPOSITORY\\s+)(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+VERSION\\s+(?<currentValue>\\d[^\\s\"]*?)\\s",
       ],
       datasourceTemplate: "github-tags",
-      extractVersionTemplate: "^v?(?<version>.+)$"
+      extractVersionTemplate: "^v?(?<version>.+)$",
     },
 
-    // ── CPM packages pinned to commit SHA ───────────────────────────────────
     // Matches: GIT_TAG 7bddff8c01f5fb931c3cb73d4aa8e66d303d97bc
-    // paired with: GIT_REPOSITORY https://github.com/owner/repo
-    // Uses git-refs datasource to track the default branch HEAD.
+    // Tracks the default branch HEAD via git-refs.
     {
       customType: "regex",
-      description: "Update CPM deps pinned to commit SHA",
+      description: "CPM deps pinned to a commit SHA",
       managerFilePatterns: ["/(^|/)cmake/cpm/[^/]+-config\\.cmake$/"],
       matchStrings: [
-        // GIT_TAG (SHA) before GIT_REPOSITORY
-        "GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})\\s+GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
-        // GIT_REPOSITORY before GIT_TAG (SHA)
-        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})\\s"
+        "GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})\\s+(?:GIT_REPOSITORY\\s+https://github\\.com/|GITHUB_REPOSITORY\\s+)(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
+        "(?:GIT_REPOSITORY\\s+https://github\\.com/|GITHUB_REPOSITORY\\s+)(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})\\s",
       ],
       datasourceTemplate: "git-refs",
       depNameTemplate: "https://github.com/{{{depName}}}.git",
-      currentValueTemplate: "main"
-    }
-  ]
+      currentValueTemplate: "main",
+    },
+  ],
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,6 +51,12 @@ jobs:
         uses: renovatebot/github-action@v46.2.1
         with:
           configurationFile: .github/renovate.json5
+          # Token pushes branches AND opens PRs.
+          # - RENOVATE_TOKEN (if set): PAT needs Contents: RW +
+          #   Pull requests: RW on this repo — otherwise branches get
+          #   pushed but PR creation silently fails.
+          # - Fallback GITHUB_TOKEN: works via the job permissions above,
+          #   but its PRs don't trigger CI workflows (GitHub recursion guard).
           token: ${{ secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
         env:
           RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}

--- a/cmake/cpm-config.cmake
+++ b/cmake/cpm-config.cmake
@@ -1,13 +1,13 @@
 include(FetchContent)
 
-set(cpm_version "0.42.1")
-set(cpm_expected_hash
-    "f3a6dcc6a04ce9e7f51a127307fa4f699fb2bade357a8eb4c5b45df76e1dc6a5")
+# NOTE: no URL_HASH on purpose. Renovate bumps cpm_version but cannot
+# recompute a hash — a stale hash fails the configure step harder than
+# no hash. Same trust model as the GIT_TAG-pinned deps below.
+set(cpm_version "0.43.1")
 
 fetchcontent_declare(
     get_cpm
     URL "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${cpm_version}/CPM.cmake"
-    URL_HASH SHA256=${cpm_expected_hash}
     DOWNLOAD_NO_EXTRACT TRUE)
 
 fetchcontent_makeavailable(get_cpm)

--- a/cmake/cpm/lua_lang-config.cmake
+++ b/cmake/cpm/lua_lang-config.cmake
@@ -27,29 +27,3 @@ if(lua_ADDED)
     # Build as C
     set_target_properties(lua PROPERTIES LINKER_LANGUAGE C)
 endif()
-
-option(SOL2_PATCHED "whether sol2 patch has been applied" OFF)
-
-if(NOT SOL2_PATCHED)
-    set(SOL2_PATCHED
-        ON
-        CACHE BOOL "whether sol2 patch has been applied" FORCE)
-
-    cpmaddpackage(
-        NAME
-        sol2
-        GIT_REPOSITORY
-        https://github.com/ThePhD/sol2.git
-        VERSION
-        3.3.0
-        PATCHES
-        "${CMAKE_SOURCE_DIR}/cmake/patches/sol2_emplace_fix.patch")
-else()
-    cpmaddpackage(
-        NAME
-        sol2
-        GIT_REPOSITORY
-        https://github.com/ThePhD/sol2.git
-        VERSION
-        3.3.0)
-endif()


### PR DESCRIPTION
# Pull Request

## Summary
Maintenance sweep: bump CPM to 0.43.1, remove unused sol2, rebuild renovate config on `config:best-practices`.

## Related Issue
No issue — dependency maintenance. Supersedes stale renovate branches `renovate/cpm-cmake-cpm.cmake-0.x` and `renovate/thephd-sol2-3.x`.

## Changes
- `cmake/cpm-config.cmake` — CPM 0.42.1 → 0.43.1. Dropped `URL_HASH`: renovate can bump the version var but cannot recompute the hash, so every automated CPM PR would fail configure with a hash mismatch (the stale `renovate/cpm-cmake-cpm.cmake-0.x` branch had exactly this bug). Same trust model as the GIT_TAG-pinned deps.
- `cmake/cpm/lua_lang-config.cmake` — removed the sol2 block. sol2 is not referenced by any source file, and its `PATCHES` file (`cmake/patches/sol2_emplace_fix.patch`) doesn't even exist in the repo, so the block was broken dead code. lua stays.
- `.github/renovate.json5` — rebuilt on `config:best-practices` (kept `$schema`). Added `GITHUB_REPOSITORY` support to the CPM regex managers (safetyhook, lua, stb use that form and were silently untracked). Disabled the `github-actions` manager — dependabot already owns it (`.github/dependabot.yml`), no duplicate PRs. Gradle/AGP major updates disabled (need manual Android Studio verification).
- `.github/workflows/renovate.yml` — comment documenting the token scopes. Note: renovate currently pushes branches but opens no PRs — if the `RENOVATE_TOKEN` secret is set, it needs **Pull requests: RW** on this repo (or delete the secret to fall back to `GITHUB_TOKEN`).

## Verification
- [ ] CI green on this PR (configure step exercises the new CPM download)
- [x] No source references to sol2/lua_lang (verified via code search)
- [x] CPM 0.43.1 release asset exists (`CPM.cmake`, published 2026-07-06)

## Notes for Reviewer
After merge, delete the two stale `renovate/*` branches — their content is covered here.