### PR TITLE
gui: show build version + patcher URL, enable FreeType rasterizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.31)
 
 project(
     wemod_enhancer
-    VERSION 1.0.2
+    VERSION 1.0.3
     DESCRIPTION
         "Cross-platform Wand/WeMod Electron patcher and Windows ASAR fuse proxy"
     HOMEPAGE_URL "https://github.com/e-gleba/wemod_enhancer"

--- a/cmake/cpm-config.cmake
+++ b/cmake/cpm-config.cmake
@@ -35,5 +35,11 @@ if(WEMOD_ENHANCER_BUILD_GUI)
     # imgui-config.cmake creates the imgui::sdl3_renderer backend target
     # only when SDL3::SDL3 already exists, so resolve SDL3 first.
     find_package(sdl3 CONFIG REQUIRED)
+    # FreeType before imgui: imgui-config.cmake compiles
+    # misc/freetype/imgui_freetype.cpp only when a freetype target
+    # already exists. Resolved via CPM (cmake/cpm/freetype-config.cmake),
+    # so the hinted rasterizer builds from the same pinned source on
+    # every platform - no system package needed on CI.
+    find_package(freetype CONFIG REQUIRED)
     find_package(imgui CONFIG REQUIRED)
 endif()

--- a/cmake/cpm/imgui-config.cmake
+++ b/cmake/cpm/imgui-config.cmake
@@ -35,20 +35,22 @@ target_compile_features(imgui PUBLIC cxx_std_23)
 # -fmodule-mapper flags that the clang-tidy co-compilation rejects.
 set_target_properties(imgui PROPERTIES CXX_SCAN_FOR_MODULES OFF)
 
-if(Freetype_FOUND)
-    if(NOT TARGET Freetype::Freetype)
-        message(
-            FATAL_ERROR
-                "find_package(Freetype) succeeded but the imported target "
-                "Freetype::Freetype is missing. Your FreeType install may be "
-                "too old or its CMake config is incomplete.")
-    endif()
+# FreeType is resolved before imgui (see cmake/cpm-config.cmake). A CPM
+# build tree exports the plain `freetype` target; an installed FreeType
+# (CMake's FindFreetype module or freetype's exported config) provides
+# Freetype::Freetype. Accept either, preferring the canonical name.
+if(TARGET Freetype::Freetype)
+    set(imgui_freetype_target Freetype::Freetype)
+elseif(TARGET freetype)
+    set(imgui_freetype_target freetype)
+endif()
 
+if(imgui_freetype_target)
     target_sources(imgui
                    PRIVATE ${imgui_SOURCE_DIR}/misc/freetype/imgui_freetype.cpp)
 
     # PUBLIC because imgui_freetype.h exposes FreeType types to consumers.
-    target_link_libraries(imgui PUBLIC Freetype::Freetype)
+    target_link_libraries(imgui PUBLIC ${imgui_freetype_target})
     target_include_directories(
         imgui SYSTEM
         PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/misc/freetype>)

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -19,9 +19,14 @@ target_compile_features(wemod_enhancer_gui PRIVATE cxx_std_23)
 # SDL3 app callbacks (SDL_AppInit/Iterate/Event/Quit) instead of a
 # hand-written main loop. Defined here - not as a #define in the
 # source - so the translation unit stays macro-free
-# (cppcoreguidelines-macro-usage).
-target_compile_definitions(wemod_enhancer_gui
-                           PRIVATE SDL_MAIN_USE_CALLBACKS=1)
+# (cppcoreguidelines-macro-usage). WEMOD_ENHANCER_GUI_VERSION rides
+# along: the GUI shows the CMake project version it was built from, so
+# a packaged binary can never report a version that differs from its
+# package.
+target_compile_definitions(
+    wemod_enhancer_gui
+    PRIVATE SDL_MAIN_USE_CALLBACKS=1
+            WEMOD_ENHANCER_GUI_VERSION="${PROJECT_VERSION}")
 
 # No console window on Windows (GUI subsystem), .app bundle on macOS.
 set_target_properties(wemod_enhancer_gui PROPERTIES WIN32_EXECUTABLE TRUE

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -159,6 +159,12 @@ constexpr std::string_view default_python{
 // it directly - no string_view::data() that may not be null-terminated.
 constexpr const char* window_title{"WeMod Enhancer"};
 
+// Build version injected via target_compile_definitions (see
+// gui/CMakeLists.txt - same pattern as SDL_MAIN_USE_CALLBACKS): always
+// the CMake project version, so the GUI can never show a version that
+// differs from the package it was built from.
+constexpr std::string_view gui_version{WEMOD_ENHANCER_GUI_VERSION};
+
 // Base window size, multiplied by the display DPI scale at startup.
 constexpr std::int32_t window_width{1024};
 constexpr std::int32_t window_height{640};
@@ -509,7 +515,7 @@ void SDLCALL on_folder_chosen(void* userdata,
     return {};
 }
 
-// The patcher always comes from the GitHub releases: downloaded once
+// The patcher always comes from the releases: downloaded once
 // into the pref dir, then reused on every launch. Settings has a
 // button to re-download the newest release.
 [[nodiscard]] std::string cached_script()
@@ -774,9 +780,13 @@ void poll_run(app_state& state)
 // needed to reproduce it.
 [[nodiscard]] std::string env_info(const app_state& state)
 {
-    std::string info{"wemod_enhancer gui\n"};
+    std::string info{"wemod_enhancer gui "};
+    info += std::string(gui_version) + "\n";
     info += "platform: " + std::string(SDL_GetPlatform()) + " " +
         std::string(target_arch) + "\n";
+    // The exact URL the patcher is fetched from - a bug report must
+    // show which release artifact was actually downloaded.
+    info += "patcher url: " + std::string(release_asset_url) + "\n";
     info += "wemod folder: " +
         (state.install_dir.empty() ? std::string("<not set>")
                                    : state.install_dir) +
@@ -1207,6 +1217,15 @@ void draw_ui(app_state& state)
         ImGui::SameLine();
         text_colored(color_ok, "Copied!");
     }
+
+    // Build version pinned to the right end of the bottom toolbar row:
+    // the CMake project version, injected at compile time - the GUI
+    // can never show a version that differs from its package.
+    const std::string version_label{"v" + std::string(gui_version)};
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(ImGui::GetWindowContentRegionMax().x -
+                         ImGui::CalcTextSize(version_label.c_str()).x);
+    text_disabled(version_label);
 
     ImGui::End();
 }


### PR DESCRIPTION
# Pull Request

## Summary

GUI now stamps the CMake project version in the bottom-right corner and dumps it plus the exact patcher download URL into Copy output / Report bug; project version bumped to 1.0.3 to match the latest tag, and FreeType is wired in so every build gets hinted font rasterization.

## Related Issue

No issue — follow-up to #22 feedback: CI-built GUI artifacts showed `1.0.2` while the latest release is `v1.0.3`, and release builds rendered jagged/unhinted fonts with re-rasterization lag on HiDPI scales.

## Changes

- **`CMakeLists.txt`**: `VERSION 1.0.2` → `1.0.3`. Single source of truth — CPack package names and the GUI stamp both derive from it. (Root cause of "1.0.2 shown": `gui.yml` uploads raw CPack filenames like `wemod_enhancer_gui-1.0.2-Windows-x86_64.zip`; the project version was never bumped for v1.0.3. `publish_release.yml` renames artifacts, so release assets looked fine.)
- **`gui/CMakeLists.txt`**: `WEMOD_ENHANCER_GUI_VERSION="${PROJECT_VERSION}"` compile definition — same pattern as `SDL_MAIN_USE_CALLBACKS`, keeps the TU macro-free.
- **`gui/main.cpp`**:
  - `gui_version` constant from the build-system define.
  - Version stamp (`v1.0.3`) pinned to the right end of the bottom toolbar row.
  - `env_info()` first line now carries the version (`wemod_enhancer gui 1.0.3`) and a new `patcher url:` line with the exact release URL — flows into both **Copy output** and **Report bug**, so any pasted report shows which artifact URL was used.
- **`cmake/cpm-config.cmake`**: `find_package(freetype CONFIG REQUIRED)` between sdl3 and imgui. This loads the previously dead `cmake/cpm/freetype-config.cmake` → CPM builds FreeType VER-2-14-3 from pinned source. Hermetic: no new apt packages on CI, works for MSVC / clang / llvm-mingw cross / Linux alike.
- **`cmake/cpm/imgui-config.cmake`**: FreeType detection switched from `if(Freetype_FOUND)` (never set — nothing in the project ever called `find_package(Freetype)`, so **every** build, local included, used the stb_truetype fallback) to target detection: `Freetype::Freetype` (installed FreeType) or plain `freetype` (CPM build tree — upstream only exports the `Freetype::Freetype` name at install time via `EXPORT_NAME`).

## Verification

- [ ] `cmake --workflow --preset=gui-linux-gcc-amd64-full` passes (CI `gui_multiplatform_workflow` runs all 6 matrix jobs on this PR)
- [ ] Configure log no longer prints `imgui: FreeType not found — custom font rasterizer disabled.` and `misc/freetype/imgui_freetype.cpp` compiles
- [ ] GUI shows `v1.0.3` bottom-right; Copy output contains `wemod_enhancer gui 1.0.3` + `patcher url: ...`
- [ ] `pre-commit run --all-files` passes (formatting, lint)

## Notes for Reviewer

- Local builds only *looked* anti-aliased because dev displays usually run at 100% scale: no `FontScaleDpi` re-rasterization, no framebuffer upscale. The rasterizer (stb) was identical everywhere. FreeType adds hinting (crisp at fractional DPI like 1.25/1.5) and rasterizes glyphs much faster, which also reduces the dynamic-atlas re-rasterization hitches seen when scaling.
- `cmake/cpm/freetype-config.cmake` has a duplicate `EXCLUDE_FROM_ALL` argument (harmless) — left as-is to keep this diff surgical; can be cleaned separately.
- The download URL stays `releases/latest/download/...` (always the newest patcher) — only the *displayed/reported* version was stale, and that is now impossible to miss since the binary shows it.
