### PR TITLE
ci(release): auto CMake version bump after publish + gui: update button with exe-local patcher/<tag>/ layout

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: ''
+      next_version:
+        description: 'Next CMake project version, no v prefix (e.g. 1.0.5) - bot commits it to main after the release'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -372,3 +376,41 @@ jobs:
             --title "${{ inputs.version }}" \
             --notes-file release_notes.md \
             artifacts/*
+
+  # ── Post-release: bump CMake project version on main ───────────────────────
+  # Runs only after the release is published, so the tag and the
+  # just-built artifacts stay untouched. This prepares main for the NEXT
+  # release: packages always ship the project() version of their own tag.
+  bump_cmake_version:
+    name: Bump CMake version on main
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: validate_next_version
+        run: |
+          if [[ ! "${{ inputs.next_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::next_version must be plain semver, no v prefix (e.g. 1.0.5) - got '${{ inputs.next_version }}'"
+            exit 1
+          fi
+
+      - name: bump_project_version
+        run: |
+          sed -i -E "s/^([[:space:]]*VERSION[[:space:]]+)[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$/\1${{ inputs.next_version }}/" CMakeLists.txt
+          grep -E "^[[:space:]]*VERSION[[:space:]]+${{ inputs.next_version }}[[:space:]]*$" CMakeLists.txt
+
+      - name: commit_and_push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CMakeLists.txt
+          git commit -m "chore: bump CMake project version to ${{ inputs.next_version }}"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -387,6 +387,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Two release runs must never rebase-race the version commit:
+    # queue the bump jobs, never cancel them mid-push.
+    concurrency:
+      group: post-release-cmake-version-bump
+      cancel-in-progress: false
+    env:
+      # Bound once via env - never expand a workflow input into shell
+      # source (zizmor template-injection).
+      NEXT_VERSION: ${{ inputs.next_version }}
     steps:
       - name: checkout
         uses: actions/checkout@v7
@@ -396,21 +405,33 @@ jobs:
 
       - name: validate_next_version
         run: |
-          if [[ ! "${{ inputs.next_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::next_version must be plain semver, no v prefix (e.g. 1.0.5) - got '${{ inputs.next_version }}'"
+          if [[ ! "$NEXT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            printf "::error::next_version must be plain semver, no v prefix (e.g. 1.0.5) - got '%s'\n" "$NEXT_VERSION"
+            exit 1
+          fi
+          current=$(grep -E '^[[:space:]]*VERSION[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$' CMakeLists.txt | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+          if [[ -z "$current" ]]; then
+            echo "::error::could not read the current project version from CMakeLists.txt"
+            exit 1
+          fi
+          # sort -V ordering: the smaller of the two sorts first, so an
+          # equal or lower next_version sorts first - reject both.
+          lowest=$(printf '%s\n%s\n' "$current" "$NEXT_VERSION" | sort -V | head -n1)
+          if [[ "$lowest" == "$NEXT_VERSION" ]]; then
+            printf "::error::next_version (%s) must be greater than the current project version (%s)\n" "$NEXT_VERSION" "$current"
             exit 1
           fi
 
       - name: bump_project_version
         run: |
-          sed -i -E "s/^([[:space:]]*VERSION[[:space:]]+)[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$/\1${{ inputs.next_version }}/" CMakeLists.txt
-          grep -E "^[[:space:]]*VERSION[[:space:]]+${{ inputs.next_version }}[[:space:]]*$" CMakeLists.txt
+          sed -i -E "s/^([[:space:]]*VERSION[[:space:]]+)[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$/\1$NEXT_VERSION/" CMakeLists.txt
+          grep -E "^[[:space:]]*VERSION[[:space:]]+$NEXT_VERSION[[:space:]]*$" CMakeLists.txt
 
       - name: commit_and_push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CMakeLists.txt
-          git commit -m "chore: bump CMake project version to ${{ inputs.next_version }}"
+          git commit -m "chore: bump CMake project version to $NEXT_VERSION"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ list(
     "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
 
 # When cross-compiling, CMAKE_FIND_ROOT_PATH_MODE_PACKAGE is
-typically set to ONLY in the toolchain file. That restricts
+# typically set to ONLY in the toolchain file. That restricts
 # find_package() to searching only under CMAKE_FIND_ROOT_PATH
 # and CMAKE_SYSROOT — our local cmake/ dirs wouldn't be found.
 # Adding them to CMAKE_FIND_ROOT_PATH fixes this

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.31)
 
 project(
     wemod_enhancer
-    VERSION 1.0.3
+    VERSION 1.0.4
     DESCRIPTION
         "Cross-platform Wand/WeMod Electron patcher and Windows ASAR fuse proxy"
     HOMEPAGE_URL "https://github.com/e-gleba/wemod_enhancer"
@@ -29,7 +29,7 @@ list(
     "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
 
 # When cross-compiling, CMAKE_FIND_ROOT_PATH_MODE_PACKAGE is
-# typically set to ONLY in the toolchain file. That restricts
+typically set to ONLY in the toolchain file. That restricts
 # find_package() to searching only under CMAKE_FIND_ROOT_PATH
 # and CMAKE_SYSROOT — our local cmake/ dirs wouldn't be found.
 # Adding them to CMAKE_FIND_ROOT_PATH fixes this

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -37,7 +37,7 @@
 //   - SDL3 owns the platform glue: SDL_GetEnvironmentVariable instead
 //     of std::getenv, SDL_GetBasePath for the exe dir the patcher is
 //     unpacked next to, SDL_GetUserFolder for Downloads,
-//     SDL_GetPlatform for diagnostics, RAII for SDL_malloc'd strings.
+//     SDL_GetPlatform for diagnostics.
 //   - gsl::not_null for pointers out of C callbacks, gsl::finally for
 //     SDL_Quit, Expects() for preconditions; app state ownership is a
 //     std::unique_ptr (make_unique in SDL_AppInit, re-acquired in
@@ -235,13 +235,6 @@ struct app_state final
     std::string python_version;  // e.g. "Python 3.13.5"
     std::string python_location; // e.g. /usr/bin/python3
 };
-
-// RAII for SDL_malloc'd strings (SDL_GetBasePath, SDL_GetPrefPath).
-struct sdl_free final
-{
-    void operator()(void* ptr) const noexcept { SDL_free(ptr); }
-};
-using sdl_string = std::unique_ptr<char, sdl_free>;
 
 // --- Vararg-free ImGui helpers --------------------------------------
 // ImGui's formatted text API is printf-style varargs; these wrappers
@@ -508,11 +501,13 @@ void SDLCALL on_folder_chosen(void* userdata,
 
 // Dir the running exe sits in. SDL_GetBasePath picks it on every OS;
 // the patcher is unpacked next to the exe (patcher/<tag>/) so the
-// whole install stays one self-contained, movable folder.
+// whole install stays one self-contained, movable folder. The result
+// is SDL-owned internal memory (const char*, cached internally) -
+// unlike SDL_GetPrefPath it must NOT be freed, so plain pointer it is.
 [[nodiscard]] fs::path exe_dir()
 {
-    if (const sdl_string base{SDL_GetBasePath()}) {
-        return {base.get()};
+    if (const char* base{SDL_GetBasePath()}) {
+        return {base};
     }
     return fs::temp_directory_path() / "wemod_enhancer";
 }

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -6,10 +6,15 @@
 // scrolling log.
 //
 // The patcher itself always comes from the GitHub releases: on first
-// run the app downloads the latest asset (curl on Linux, PowerShell on
-// Windows), unpacks wemod_enhancer.py + version.dll into the SDL pref
-// dir and reuses that copy from then on. No local files, no build-
-// machine paths baked in - the exe can be moved between PCs as-is.
+// run the app resolves the newest release tag, downloads that asset
+// (curl on Linux, PowerShell on Windows) and unpacks
+// wemod_enhancer.py + version.dll into patcher/<tag>/ next to the
+// exe. The newest tag dir wins at startup, so the install stays one
+// self-contained movable folder - no app-data dirs, no build-machine
+// paths baked in. A background check on every launch compares the
+// patcher in use against the newest release: a newer one raises an
+// "update available" hint with an Update button in the toolbar, and
+// the downloaded tag is used right away and on every later launch.
 // The only thing the user provides is the WeMod folder (auto-detected
 // at startup, so usually that is just pressing Patch).
 //
@@ -30,9 +35,9 @@
 //     #ifdef wherever both branches compile; the preprocessor only
 //     remains where names do not exist cross-platform (popen/pclose).
 //   - SDL3 owns the platform glue: SDL_GetEnvironmentVariable instead
-//     of std::getenv, SDL_GetPrefPath instead of hand-rolled cache-dir
-//     logic, SDL_GetUserFolder for Downloads, SDL_GetPlatform for
-//     diagnostics, RAII for SDL_malloc'd strings.
+//     of std::getenv, SDL_GetBasePath for the exe dir the patcher is
+//     unpacked next to, SDL_GetUserFolder for Downloads,
+//     SDL_GetPlatform for diagnostics, RAII for SDL_malloc'd strings.
 //   - gsl::not_null for pointers out of C callbacks, gsl::finally for
 //     SDL_Quit, Expects() for preconditions; app state ownership is a
 //     std::unique_ptr (make_unique in SDL_AppInit, re-acquired in
@@ -125,17 +130,20 @@ constexpr std::string_view target_arch{"arm64"};
 constexpr std::string_view target_arch{"unknown"};
 #endif
 
-// Latest GitHub release asset carrying the patcher (wemod_enhancer.py
-// + version.dll under bin/). Downloaded on first run - the only remote
-// endpoint the app knows; everything local is derived at runtime.
-constexpr std::string_view release_asset_url{
+// GitHub release asset carrying the patcher (wemod_enhancer.py +
+// version.dll under bin/). Downloaded on first run and on Update -
+// the only remote endpoint the app knows; everything local is derived
+// at runtime.
+constexpr std::string_view release_asset_name{
     is_windows
-        ? std::string_view(
-              "https://github.com/e-gleba/wemod_enhancer/releases/latest/download/"
-              "wemod_enhancer-windows-msvc-amd64.zip")
+        ? std::string_view("wemod_enhancer-windows-msvc-amd64.zip")
         : std::string_view(
-              "https://github.com/e-gleba/wemod_enhancer/releases/latest/download/"
               "wemod_enhancer-windows-llvm-mingw-amd64.tar.xz")};
+
+// Newest-release lookup for the update check: the JSON carries the
+// tag the download URL and the patcher/<tag>/ dir are built from.
+constexpr std::string_view release_api_url{
+    "https://api.github.com/repos/e-gleba/wemod_enhancer/releases/latest"};
 
 // "Download WeMod" endpoints. Windows: the official installer direct
 // link (what https://www.wemod.com/download serves). Linux: the
@@ -191,8 +199,9 @@ struct run_result final
 
 // What the current background command is, so poll_run() can react to
 // completion: refresh resolved paths after a download, record the
-// Python probe result, narrate the WeMod fetch.
-enum class run_kind : std::uint8_t { patcher, bootstrap, probe, wemod };
+// Python probe result, narrate the WeMod fetch, apply the update
+// check.
+enum class run_kind : std::uint8_t { patcher, bootstrap, probe, wemod, check };
 static_assert(std::is_enum_v<run_kind>);
 
 // Python probe tri-state: unknown / failed / works.
@@ -207,6 +216,7 @@ struct app_state final
     SDL_Renderer* renderer{nullptr};
     std::string install_dir;
     std::string script_path;
+    std::string patcher_version; // tag of the patcher in use, e.g. "v1.0.4"
     std::string python;
     std::string version_dll; // empty = the script auto-detects it
     std::string log;
@@ -217,6 +227,9 @@ struct app_state final
     bool has_run{false};
     std::int32_t last_exit_code{0};
     float copied_flash{0.0F}; // seconds left of "Copied!" feedback
+    // --- update check ---
+    std::string latest_tag;       // newest release tag, empty until checked
+    bool update_requested{false}; // a finished check downloads right away
     // --- diagnostics ---
     probe_state python_ok{probe_state::unknown};
     std::string python_version;  // e.g. "Python 3.13.5"
@@ -350,13 +363,16 @@ void sdl_log_error(const std::string& message)
     return result;
 }
 
-// "app-10.2.3" -> {10, 2, 3}; non-numeric tokens become 0.
+// "app-10.2.3" or "v1.2.3" -> {10, 2, 3}; non-numeric tokens become 0.
 [[nodiscard]] constexpr std::vector<std::int32_t>
 version_parts(std::string name)
 {
     constexpr std::string_view prefix{"app-"};
     if (name.starts_with(prefix)) {
         name.erase(0, prefix.size());
+    }
+    if (name.starts_with('v')) { // release tags
+        name.erase(0, 1);
     }
     std::vector<std::int32_t> parts;
     std::size_t pos{0};
@@ -490,15 +506,21 @@ void SDLCALL on_folder_chosen(void* userdata,
     }
 }
 
-// Per-user writable dir for the downloaded patcher. SDL_GetPrefPath
-// picks the right place on every OS (%APPDATA%\org\app on Windows,
-// XDG data home on Linux) and creates the directory for us.
-[[nodiscard]] fs::path bootstrap_root()
+// Dir the running exe sits in. SDL_GetBasePath picks it on every OS;
+// the patcher is unpacked next to the exe (patcher/<tag>/) so the
+// whole install stays one self-contained, movable folder.
+[[nodiscard]] fs::path exe_dir()
 {
-    if (const sdl_string pref{SDL_GetPrefPath("e-gleba", "wemod_enhancer")}) {
-        return {pref.get()};
+    if (const sdl_string base{SDL_GetBasePath()}) {
+        return {base.get()};
     }
     return fs::temp_directory_path() / "wemod_enhancer";
+}
+
+// Root of the unpacked patcher releases: patcher/<tag>/ per version.
+[[nodiscard]] fs::path patcher_root()
+{
+    return exe_dir() / "patcher";
 }
 
 // The release archive carries the CLI under bin/; search recursively
@@ -515,12 +537,47 @@ void SDLCALL on_folder_chosen(void* userdata,
     return {};
 }
 
-// The patcher always comes from the releases: downloaded once
-// into the pref dir, then reused on every launch. Settings has a
-// button to re-download the newest release.
+// The <tag> in patcher/<tag>/... that holds this script - the version
+// of the patcher in use. Empty when the script lives elsewhere.
+[[nodiscard]] std::string patcher_tag_of(const fs::path& script)
+{
+    if (script.empty()) {
+        return {};
+    }
+    std::error_code ec;
+    const fs::path rel{fs::relative(script, patcher_root(), ec)};
+    if (ec || rel.empty() || rel.begin() == rel.end()) {
+        return {};
+    }
+    return rel.begin()->string();
+}
+
+// The patcher always comes from the releases: every downloaded tag
+// sits in its own patcher/<tag>/ dir next to the exe and the newest
+// one wins, so an Update download is used on this launch and every
+// later one. Settings has a button to fetch the newest release.
 [[nodiscard]] std::string cached_script()
 {
-    return find_script_under(bootstrap_root() / "patcher").string();
+    std::error_code ec;
+    const fs::path root{patcher_root()};
+    if (!fs::is_directory(root, ec)) {
+        return {};
+    }
+    std::vector<fs::path> scripts;
+    for (const auto& entry : fs::directory_iterator(root, ec)) {
+        if (!entry.is_directory(ec)) {
+            continue;
+        }
+        if (const fs::path script{find_script_under(entry.path())};
+            !script.empty()) {
+            scripts.push_back(script);
+        }
+    }
+    const auto newest{
+        std::ranges::max_element(scripts, {}, [](const fs::path& path) {
+            return version_parts(patcher_tag_of(path));
+        })};
+    return newest == scripts.end() ? std::string{} : newest->string();
 }
 
 // Launch a background command and stream its output into the log.
@@ -562,34 +619,75 @@ void start_run(app_state& state, const char* subcommand)
     start_command(state, run_kind::patcher, shown, command);
 }
 
-// Download + unpack the latest release asset with the tools every base
-// OS install already has: curl + tar on Linux, PowerShell on Windows.
-// The log shows the real command line - no shorthand.
-void start_bootstrap(app_state& state)
+// Download URL for one release tag; an empty tag means the latest
+// release (used only for diagnostics - downloads always name a tag).
+[[nodiscard]] std::string asset_url_for(const std::string_view tag)
 {
-    const fs::path dir{bootstrap_root() / "patcher"};
+    const std::string base{
+        "https://github.com/e-gleba/wemod_enhancer/releases/"};
+    if (tag.empty()) {
+        return base + "latest/download/" + std::string(release_asset_name);
+    }
+    return base + "download/" + std::string(tag) + "/" +
+        std::string(release_asset_name);
+}
+
+// Download + unpack one release tag into patcher/<tag>/ next to the
+// exe, with the tools every base OS install already has: curl + tar
+// on Linux, PowerShell on Windows. The log shows the real command
+// line - no shorthand.
+void start_bootstrap(app_state& state, const std::string& tag)
+{
+    Expects(!tag.empty());
+    const fs::path dir{patcher_root() / tag};
+    const std::string url{asset_url_for(tag)};
     std::string command;
     if constexpr (is_windows) {
-        const fs::path archive{bootstrap_root() / "patcher.zip"};
+        const fs::path archive{patcher_root() / (tag + ".zip")};
         command =
             "powershell -NoProfile -ExecutionPolicy Bypass -Command \""
             "$ProgressPreference='SilentlyContinue'; "
             "New-Item -ItemType Directory -Force -Path '" + dir.string() +
             "' | Out-Null; "
-            "Invoke-WebRequest -Uri '" + std::string(release_asset_url) +
+            "Invoke-WebRequest -Uri '" + url +
             "' -OutFile '" + archive.string() + "'; "
             "Expand-Archive -Force -Path '" + archive.string() +
             "' -DestinationPath '" + dir.string() + "'\"";
     } else {
-        const fs::path archive{bootstrap_root() / "patcher.tar.xz"};
+        const fs::path archive{patcher_root() / (tag + ".tar.xz")};
         command =
             "mkdir -p " + shell_quote(dir.string()) + " && curl -fL " +
-            shell_quote(release_asset_url) + " -o " +
+            shell_quote(url) + " -o " +
             shell_quote(archive.string()) + " && tar -xf " +
             shell_quote(archive.string()) + " -C " +
             shell_quote(dir.string());
     }
     start_command(state, run_kind::bootstrap, command, command);
+}
+
+// Resolve the newest release tag in the background. With
+// download_after (first run without a patcher, Update / Download now)
+// the download of that tag starts right away; otherwise a newer tag
+// only raises the Update hint in the toolbar.
+void start_check(app_state& state, const bool download_after)
+{
+    if (download_after) {
+        state.update_requested = true;
+    }
+    std::string command;
+    if constexpr (is_windows) {
+        command =
+            "powershell -NoProfile -ExecutionPolicy Bypass -Command \""
+            "(Invoke-RestMethod -Uri '" + std::string(release_api_url) +
+            "').tag_name\"";
+    } else {
+        // [ -n "$out" ]: a failed curl still exits 0 through the pipe,
+        // so the empty result is what makes the check fail loudly.
+        command = "out=$(curl -fsSL " + shell_quote(release_api_url) +
+            " | grep -m1 '\"tag_name\"' | cut -d'\"' -f4) && "
+            "[ -n \"$out\" ] && echo \"$out\"";
+    }
+    start_command(state, run_kind::check, command, command);
 }
 
 // "Download WeMod" does the real thing, no dialogs:
@@ -606,7 +704,7 @@ void start_wemod_download(app_state& state)
         const char* downloads_c{SDL_GetUserFolder(SDL_FOLDER_DOWNLOADS)};
         const fs::path downloads{downloads_c != nullptr
                                      ? downloads_c
-                                     : bootstrap_root().string()};
+                                     : exe_dir().string()};
         const fs::path setup{downloads / "WeMod-Setup.exe"};
         const std::string command{
             "powershell -NoProfile -ExecutionPolicy Bypass -Command \""
@@ -689,6 +787,28 @@ void parse_probe(app_state& state, const std::string& output)
     }
 }
 
+// First line of the update-check output, trimmed and validated:
+// "v1.0.4" stays, anything else (error text, empty) means no tag.
+[[nodiscard]] std::string parse_release_tag(const std::string& output)
+{
+    const std::size_t eol{output.find('\n')};
+    std::string_view line{output.data(),
+                          eol == std::string::npos ? output.size() : eol};
+    while (!line.empty() && (line.back() == '\r' || line.back() == ' ')) {
+        line.remove_suffix(1);
+    }
+    if (line.size() < 2 || line.front() != 'v') {
+        return {};
+    }
+    const std::string_view digits{line.substr(1)};
+    const bool valid{
+        std::ranges::all_of(digits, [](const char c) {
+            return (c >= '0' && c <= '9') || c == '.';
+        }) &&
+        digits.find_first_of("0123456789") != std::string_view::npos};
+    return valid ? std::string(line) : std::string{};
+}
+
 void poll_run(app_state& state)
 {
     if (!state.running ||
@@ -722,6 +842,7 @@ void poll_run(app_state& state)
             break;
         }
         if (state.script_path = cached_script(); !state.script_path.empty()) {
+            state.patcher_version = patcher_tag_of(state.script_path);
             state.log += "patcher ready: " + state.script_path + "\n\n";
             start_probe(state); // chain: confirm Python works too
         } else {
@@ -764,6 +885,41 @@ void poll_run(app_state& state)
         state.python_ok = result.exit_code == 0 ? probe_state::works
                                                 : probe_state::failed;
         parse_probe(state, result.output);
+        // Startup chain continues: with a patcher already in place the
+        // probe ran first, so the background update check starts now.
+        // (First run checked before downloading - latest_tag is set.)
+        if (state.latest_tag.empty()) {
+            start_check(state, false);
+        }
+        break;
+    case run_kind::check:
+        if (result.exit_code != 0) {
+            state.update_requested = false;
+            state.log +=
+                "error: could not check for updates - the network or "
+                "GitHub is unreachable.\n"
+                "  the current patcher keeps working; the next launch "
+                "retries the check.\n\n";
+            break;
+        }
+        state.latest_tag = parse_release_tag(result.output);
+        if (state.latest_tag.empty()) {
+            state.update_requested = false;
+            state.log +=
+                "error: the update check returned no release tag.\n"
+                "  fix: press Report bug below - this should not happen.\n\n";
+            break;
+        }
+        if (state.update_requested || state.script_path.empty()) {
+            // First run without a patcher, or Update / Download now:
+            // fetch the tag the check just resolved.
+            state.update_requested = false;
+            start_bootstrap(state, state.latest_tag);
+        } else if (state.latest_tag != state.patcher_version) {
+            state.log += "patcher update available: " + state.latest_tag +
+                " (in use: " + state.patcher_version + ").\n"
+                "  press Update below to download it next to the exe.\n\n";
+        }
         break;
     case run_kind::patcher:
         if (result.exit_code != 0) {
@@ -784,9 +940,9 @@ void poll_run(app_state& state)
     info += std::string(gui_version) + "\n";
     info += "platform: " + std::string(SDL_GetPlatform()) + " " +
         std::string(target_arch) + "\n";
-    // The exact URL the patcher is fetched from - a bug report must
+    // The exact URL the patcher was fetched from - a bug report must
     // show which release artifact was actually downloaded.
-    info += "patcher url: " + std::string(release_asset_url) + "\n";
+    info += "patcher url: " + asset_url_for(state.patcher_version) + "\n";
     info += "wemod folder: " +
         (state.install_dir.empty() ? std::string("<not set>")
                                    : state.install_dir) +
@@ -892,6 +1048,8 @@ bool fit_button(const char* label)
     switch (kind) {
     case run_kind::bootstrap:
         return "Downloading the latest patcher release...";
+    case run_kind::check:
+        return "Checking for updates...";
     case run_kind::probe:
         return "Checking Python...";
     case run_kind::wemod:
@@ -1108,13 +1266,17 @@ void draw_ui(app_state& state)
 
         field_label("Patcher");
         help_marker(
-            "wemod_enhancer.py + version.dll, downloaded from the latest "
-            "GitHub release into the app data dir. Download now fetches "
-            "the newest release again.",
+            "wemod_enhancer.py + version.dll, downloaded from the GitHub "
+            "releases into patcher/<tag>/ next to the exe - the newest "
+            "tag wins. Download now fetches the newest release again.",
             "https://github.com/e-gleba/wemod_enhancer/releases/latest");
         ImGui::SameLine();
         if (script_ok) {
-            text_colored(color_ok, "ready");
+            text_colored(color_ok,
+                         "ready" +
+                             (state.patcher_version.empty()
+                                  ? std::string{}
+                                  : " " + state.patcher_version));
             ImGui::SameLine();
             text_disabled(state.script_path);
         } else if (state.running && state.kind == run_kind::bootstrap) {
@@ -1124,7 +1286,7 @@ void draw_ui(app_state& state)
             ImGui::SameLine();
             ImGui::BeginDisabled(state.running);
             if (fit_button("Download now")) {
-                start_bootstrap(state);
+                start_check(state, true);
             }
             ImGui::EndDisabled();
         }
@@ -1218,6 +1380,28 @@ void draw_ui(app_state& state)
         text_colored(color_ok, "Copied!");
     }
 
+    // Update hint in the toolbar: only when the background check found
+    // a release newer than the patcher in use. Update re-checks (the
+    // hint may be stale) and downloads the newest tag right away.
+    const bool update_available{!state.latest_tag.empty() &&
+                                !state.script_path.empty() &&
+                                state.latest_tag != state.patcher_version};
+    if (update_available) {
+        ImGui::SameLine();
+        text_colored(color_warn, "update available: " + state.latest_tag);
+        ImGui::SameLine();
+        ImGui::BeginDisabled(state.running);
+        if (fit_button("Update")) {
+            start_check(state, true);
+        }
+        ImGui::EndDisabled();
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+            tooltip_text("Download patcher " + state.latest_tag +
+                         " into patcher/" + state.latest_tag +
+                         "/ next to the exe and use it from now on");
+        }
+    }
+
     // Build version pinned to the right end of the bottom toolbar row:
     // the CMake project version, injected at compile time - the GUI
     // can never show a version that differs from its package.
@@ -1301,6 +1485,7 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
     state.renderer = renderer;
     state.install_dir = default_install_dir();
     state.script_path = cached_script();
+    state.patcher_version = patcher_tag_of(state.script_path);
     state.python = std::string(default_python);
 
     // Say what was auto-detected up front - the log doubles as the
@@ -1313,10 +1498,12 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
             "auto-detected WeMod install: " + state.install_dir + "\n\n";
     }
 
-    // The patcher always comes from the releases: reuse the unpacked
-    // copy when present, otherwise download + unpack the latest asset.
+    // The patcher always comes from the releases: reuse the newest
+    // unpacked tag when present, otherwise resolve the newest release
+    // tag and download it. The update check rides along either way -
+    // chained after the Python probe when a patcher already exists.
     if (state.script_path.empty()) {
-        start_bootstrap(state);
+        start_check(state, true);
     } else {
         state.log += "using downloaded patcher: " + state.script_path + "\n\n";
         start_probe(state);


### PR DESCRIPTION
# Pull Request

## Summary
Two-sided version story: releases now auto-bump `project(VERSION)` via bot commit, and the GUI checks for newer releases itself — an Update button downloads the newest patcher into `patcher/<tag>/` next to the exe.

## Related Issue
No issue — release automation + GUI self-update. Root cause of the stale-version release: the `1.0.2 -> 1.0.3` bump was done by hand in de4b4221 ("CPack artifact names carried the stale 1.0.2"), so shipped packages lagged the tag.

## Changes

**`.github/workflows/publish_release.yml`** (+42, then hardened per review)
- New **required** `workflow_dispatch` input `next_version` — plain semver, **no `v` prefix** (e.g. `1.0.5`). Written into CMake code, not a tag; tags keep their `v` via the existing `version` input.
- New `bump_cmake_version` job (`needs: release`, runs only after publish): validates the input, `sed`-rewrites only the `project()` VERSION line (anchored at line start — `cmake_minimum_required(VERSION 3.31)` can't match), `grep`-verifies, commits as `github-actions[bot]`, pushes to `main` (with `pull --rebase` first).
- Review hardening (ffac1a8): input bound once via job-level `NEXT_VERSION` env — no `${{ inputs.* }}` expansion in shell source (zizmor template-injection); `validate_next_version` rejects `next_version` equal/lower than the current `project()` version (`sort -V` ordering); job-level concurrency `post-release-cmake-version-bump` with `cancel-in-progress: false` so concurrent bumps queue.

**`CMakeLists.txt`** (1 line)
- `VERSION 1.0.3` → `1.0.4`

**`gui/main.cpp`** (+235 / −48)
- **Update check**: every launch resolves the newest release tag in the background (`curl | grep | cut` against `releases/latest` API on Linux, `Invoke-RestMethod ... .tag_name` on Windows). A newer tag raises an `update available: vX.Y.Z` hint + **Update** button in the bottom toolbar (warn color, next to the version label).
- **Update / Download now** re-check (hint may be stale), then download that exact tag's asset and unpack into **`patcher/<tag>/` next to the exe** via `SDL_GetBasePath` — replaces the old SDL pref dir (`~/.local/share/...`), so the install is one self-contained movable folder.
- **Newest-tag-wins**: `cached_script()` scans `patcher/*/`, picks the highest version (`version_parts` now strips a leading `v`), so a downloaded update is used **immediately** (script path repointed in-place) and on **every later launch** — no manual steps.
- Startup chains: first run = check → download → Python probe; patcher present = probe → check (hint only, never auto-downloads over a working patcher).
- Failures are loud and narrated in the log (offline check, missing tag, download errors all say what + how to fix); `env_info` now reports the exact tagged artifact URL in use for bug reports.
- Style kept: vararg-free text helpers, `if constexpr` platform split, gsl preconditions, ASCII-only literals, real command lines shown in the log.

Resulting release flow: dispatch `publish_release` with `version=v1.0.4`, `next_version=1.0.5` → artifacts ship stamped **1.0.4** (this PR's bump) → release publishes → bot sets main to **1.0.5**. GUIs in the wild see `update available: v1.0.4` on next launch.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes — not run locally; the existing CI matrix covers `gui/**` + `CMakeLists.txt` on this PR (both are in its path filter)
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets) — covered by same CI
- [ ] `pre-commit run --all-files` passes (formatting, lint) — not run locally; clang-format/clang-tidy co-compile runs in CI
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`) — n/a, no toolchain changes
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features) — n/a, no user-facing docs changes
- [ ] `docker build` succeeds if Dockerfiles changed — n/a
- [x] Full diff reviewed hunk-by-hunk after every push: `CMakeLists.txt` 1 line, workflow scoped to the new input + job, `gui/main.cpp` only the intended hunks
- [x] `sed`/`grep` patterns validated against current `CMakeLists.txt` — exactly one line matches
- [x] Both `switch (run_kind)` statements cover the new `check` value (no `-Wswitch` fallout)
- [x] CodeRabbit threads addressed: template-injection (env binding), non-increasing version (sort -V gate), concurrent bumps (job concurrency) — all three fixed in ffac1a8

## Notes for Reviewer
- The bot bump commit on main triggers `cmake_multiplatform_workflow` (path filter includes `**/CMakeLists.txt`) — left as-is intentionally: free validation of every bump. Say the word if you'd rather add `[skip ci]`.
- Bot pushes straight to `main`, mirroring the existing direct tag push. If you later enable branch protection on `main`, the job needs PR + auto-merge instead.
- Pre-existing `${{ inputs.version }}` / `${{ inputs.previous_tag }}` interpolations in the `release` job share the old template-injection pattern — deliberately untouched here (not this PR's code); worth a follow-up.
- Old patcher copies in the SDL pref dir (`~/.local/share/e-gleba/wemod_enhancer/`, `%APPDATA%\e-gleba\wemod_enhancer`) are simply ignored now — not deleted. First launch after this update re-downloads once into the new exe-local layout.
- Exe dir must be writable for downloads (true for the zip/tar.xz distribution; not for e.g. `/usr/bin`). Failure mode is a clear log error, not a crash.
- GitHub API rate limit for the update check: 60 req/hr per IP unauthenticated — one call per launch, fine in practice.
- First use of the release action after merge: dispatch shows the new required `next_version` field; for releasing `v1.0.4` enter `1.0.5`.