### PR TITLE
build(cmake): modernize to strict target-based CMake 3.31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,30 +8,40 @@ project(
     HOMEPAGE_URL "https://github.com/e-gleba/wemod_enhancer"
     LANGUAGES C CXX)
 
-# No C++ modules in use: skip the CMP0155 source scan on every target.
+# No C++20 modules in use — do not pay for the module dependency scan.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
-# Opt-in Dear ImGui frontend for the Python patcher CLI.
-# OFF: the plain version.dll build never touches SDL3/imgui.
+# Opt-in Dear ImGui desktop frontend for the Python patcher CLI.
+# OFF by default: the plain version.dll build never touches SDL3/imgui.
 option(WEMOD_ENHANCER_BUILD_GUI "Build the ImGui desktop app (opt-in)" OFF)
 
-include(GNUInstallDirs)
-
-# CMAKE_CURRENT_LIST_DIR, not CMAKE_SOURCE_DIR: keeps working when the
-# project is consumed via add_subdirectory()/FetchContent.
-set(wemod_cmake_dirs
+# CMAKE_CURRENT_LIST_DIR is used instead of CMAKE_SOURCE_DIR so
+# that this file works correctly if the project is ever consumed
+# as a subdirectory of a larger build.
+# Ref: Professional CMake §8.3 "Project-relative Variables"
+list(
+    APPEND
+    CMAKE_PREFIX_PATH
     "${CMAKE_CURRENT_LIST_DIR}/cmake"
     "${CMAKE_CURRENT_LIST_DIR}/cmake/description"
     "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
-list(APPEND CMAKE_PREFIX_PATH ${wemod_cmake_dirs})
 
-# Cross toolchain files may set CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY,
-# which hides the local *-config.cmake packages from find_package().
+# When cross-compiling, CMAKE_FIND_ROOT_PATH_MODE_PACKAGE is
+# typically set to ONLY in the toolchain file. That restricts
+# find_package() to searching only under CMAKE_FIND_ROOT_PATH
+# and CMAKE_SYSROOT — our local cmake/ dirs wouldn't be found.
+# Adding them to CMAKE_FIND_ROOT_PATH fixes this
 if(CMAKE_CROSSCOMPILING)
-    list(APPEND CMAKE_FIND_ROOT_PATH ${wemod_cmake_dirs})
+    list(
+        APPEND
+        CMAKE_FIND_ROOT_PATH
+        "${CMAKE_CURRENT_LIST_DIR}/cmake"
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/description"
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
 endif()
 
 find_package(cpm CONFIG REQUIRED)
+
 find_package(warnings CONFIG REQUIRED)
 
 if(PROJECT_IS_TOP_LEVEL)
@@ -41,39 +51,50 @@ if(PROJECT_IS_TOP_LEVEL)
     find_package(ct_doxygen CONFIG REQUIRED)
 endif()
 
-# version.dll and the GUI are mutually exclusive:
-#   - src/ includes <windows.h> unconditionally: Windows targets only
-#     (native or cross);
-#   - a GUI configure never builds the DLL - the GUI downloads it from
-#     the GitHub releases at runtime.
+include(GNUInstallDirs)
+
+# version.dll and the GUI are mutually exclusive on purpose:
+#   - src/ includes <windows.h> unconditionally, so only a Windows
+#     target (native or cross) can compile it;
+#   - a GUI configure never builds the DLL - the GUI downloads
+#     version.dll from the GitHub releases at runtime, so a GUI
+#     package carrying a stale DLL would only cause conflicts.
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT WEMOD_ENHANCER_BUILD_GUI)
     add_subdirectory(src)
 endif()
 
-# Install rules, packaging, and the end-user GUI belong to the top-level
-# build only: a parent project keeps control of testing and packaging.
+# CTest, CPack, and install rules for top-level metadata files
+# should only run when this project owns the build. If another
+# project pulls us in via add_subdirectory() or FetchContent,
+# it controls testing and packaging — we should not interfere.
+# Ref: Professional CMake §8.3, §39 "FetchContent"
 if(PROJECT_IS_TOP_LEVEL)
     find_package(package_description CONFIG REQUIRED)
 
-    # The Python patcher CLI ships inside the version.dll package; the GUI
-    # downloads it at runtime, so a GUI package must not carry it.
+    # The Python patcher CLI (wemod_enhancer.py) is part of the
+    # version.dll package - the GUI downloads it from the releases
+    # at runtime, so a GUI package must not carry it.
     if(NOT WEMOD_ENHANCER_BUILD_GUI)
         add_subdirectory(scripts)
     endif()
 
+    # The GUI is an end-user artifact: build/install it only for
+    # top-level builds. It is a standalone downloader/automator,
+    # packaged apart from the DLL:
+    # wemod_enhancer_gui-<version>-<os>-<arch>.zip / .tar.xz
     if(WEMOD_ENHANCER_BUILD_GUI)
         add_subdirectory(gui)
         set(CPACK_PACKAGE_NAME "wemod_enhancer_gui")
     endif()
 
-    # e.g. "Windows-x86_64" vs "Windows-aarch64": per-arch packages must
-    # not collide. Must be set before include(CPack) - it is read once.
-    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
-
-    # Strip packaged binaries; the build tree keeps RelWithDebInfo symbols.
+    # Strip debug info from packaged binaries: smaller artifacts.
+    # The build tree keeps symbols (RelWithDebInfo), so release
+    # crashes stay debuggable from the build dir.
     set(CPACK_STRIP_FILES ON)
 
-    # include(CPack) reads the CPACK_* variables at include-time and
-    # ignores later changes - keep it last.
+    # include(CPack) must come AFTER all CPACK_* variables
+    # are set — it reads them at include-time and ignores
+    # any changes made afterward.
+    # Ref: Professional CMake §36.1 "Packaging Basics"
     include(CPack)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,42 +8,30 @@ project(
     HOMEPAGE_URL "https://github.com/e-gleba/wemod_enhancer"
     LANGUAGES C CXX)
 
-set(PROJECT_VENDOR "e-gleba")
-set(PROJECT_CONTACT "evgeniy.gleba@yandex.ru")
-set(PROJECT_LICENSE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/license.md")
-set(PROJECT_README_FILE "${CMAKE_CURRENT_SOURCE_DIR}/readme.md")
+# No C++ modules in use: skip the CMP0155 source scan on every target.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
-# Opt-in Dear ImGui desktop frontend for the Python patcher CLI.
-# OFF by default: the plain version.dll build never touches SDL3/imgui.
+# Opt-in Dear ImGui frontend for the Python patcher CLI.
+# OFF: the plain version.dll build never touches SDL3/imgui.
 option(WEMOD_ENHANCER_BUILD_GUI "Build the ImGui desktop app (opt-in)" OFF)
 
-# CMAKE_CURRENT_LIST_DIR is used instead of CMAKE_SOURCE_DIR so
-# that this file works correctly if the project is ever consumed
-# as a subdirectory of a larger build.
-# Ref: Professional CMake §8.3 "Project-relative Variables"
-list(
-    APPEND
-    CMAKE_PREFIX_PATH
+include(GNUInstallDirs)
+
+# CMAKE_CURRENT_LIST_DIR, not CMAKE_SOURCE_DIR: keeps working when the
+# project is consumed via add_subdirectory()/FetchContent.
+set(wemod_cmake_dirs
     "${CMAKE_CURRENT_LIST_DIR}/cmake"
     "${CMAKE_CURRENT_LIST_DIR}/cmake/description"
     "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
+list(APPEND CMAKE_PREFIX_PATH ${wemod_cmake_dirs})
 
-# When cross-compiling, CMAKE_FIND_ROOT_PATH_MODE_PACKAGE is
-# typically set to ONLY in the toolchain file. That restricts
-# find_package() to searching only under CMAKE_FIND_ROOT_PATH
-# and CMAKE_SYSROOT — our local cmake/ dirs wouldn't be found.
-# Adding them to CMAKE_FIND_ROOT_PATH fixes this
+# Cross toolchain files may set CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY,
+# which hides the local *-config.cmake packages from find_package().
 if(CMAKE_CROSSCOMPILING)
-    list(
-        APPEND
-        CMAKE_FIND_ROOT_PATH
-        "${CMAKE_CURRENT_LIST_DIR}/cmake"
-        "${CMAKE_CURRENT_LIST_DIR}/cmake/description"
-        "${CMAKE_CURRENT_LIST_DIR}/cmake/code_quality")
+    list(APPEND CMAKE_FIND_ROOT_PATH ${wemod_cmake_dirs})
 endif()
 
 find_package(cpm CONFIG REQUIRED)
-
 find_package(warnings CONFIG REQUIRED)
 
 if(PROJECT_IS_TOP_LEVEL)
@@ -53,54 +41,39 @@ if(PROJECT_IS_TOP_LEVEL)
     find_package(ct_doxygen CONFIG REQUIRED)
 endif()
 
-# version.dll and the GUI are mutually exclusive on purpose:
-#   - src/ includes <windows.h> unconditionally, so only a Windows
-#     target (native or cross) can compile it;
-#   - a GUI configure never builds the DLL - the GUI downloads
-#     version.dll from the GitHub releases at runtime, so a GUI
-#     package carrying a stale DLL would only cause conflicts.
-if(WIN32 AND NOT WEMOD_ENHANCER_BUILD_GUI)
+# version.dll and the GUI are mutually exclusive:
+#   - src/ includes <windows.h> unconditionally: Windows targets only
+#     (native or cross);
+#   - a GUI configure never builds the DLL - the GUI downloads it from
+#     the GitHub releases at runtime.
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT WEMOD_ENHANCER_BUILD_GUI)
     add_subdirectory(src)
 endif()
 
-# CTest, CPack, and install rules for top-level metadata files
-# should only run when this project owns the build. If another
-# project pulls us in via add_subdirectory() or FetchContent,
-# it controls testing and packaging — we should not interfere.
-# Ref: Professional CMake §8.3, §39 "FetchContent"
+# Install rules, packaging, and the end-user GUI belong to the top-level
+# build only: a parent project keeps control of testing and packaging.
 if(PROJECT_IS_TOP_LEVEL)
-    include(GNUInstallDirs)
     find_package(package_description CONFIG REQUIRED)
 
-    # The Python patcher CLI (wemod_enhancer.py) is part of the
-    # version.dll package - the GUI downloads it from the releases
-    # at runtime, so a GUI package must not carry it.
+    # The Python patcher CLI ships inside the version.dll package; the GUI
+    # downloads it at runtime, so a GUI package must not carry it.
     if(NOT WEMOD_ENHANCER_BUILD_GUI)
         add_subdirectory(scripts)
     endif()
 
-    # The GUI is an end-user artifact: build/install it only for
-    # top-level builds. It is a standalone downloader/automator,
-    # packaged apart from the DLL:
-    # wemod_enhancer_gui-<version>-<os>-<arch>.zip / .tar.xz
     if(WEMOD_ENHANCER_BUILD_GUI)
         add_subdirectory(gui)
         set(CPACK_PACKAGE_NAME "wemod_enhancer_gui")
     endif()
 
-    # Append processor to system name so packages for
-    # different architectures don't collide (e.g.
-    # "Windows-x86_64" vs "Windows-aarch64").
-    string(APPEND CPACK_SYSTEM_NAME "-${CMAKE_SYSTEM_PROCESSOR}")
+    # e.g. "Windows-x86_64" vs "Windows-aarch64": per-arch packages must
+    # not collide. Must be set before include(CPack) - it is read once.
+    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
 
-    # Strip debug info from packaged binaries: smaller artifacts.
-    # The build tree keeps symbols (RelWithDebInfo), so release
-    # crashes stay debuggable from the build dir.
+    # Strip packaged binaries; the build tree keeps RelWithDebInfo symbols.
     set(CPACK_STRIP_FILES ON)
 
-    # include(CPack) must come AFTER all CPACK_* variables
-    # are set — it reads them at include-time and ignores
-    # any changes made afterward.
-    # Ref: Professional CMake §36.1 "Packaging Basics"
+    # include(CPack) reads the CPACK_* variables at include-time and
+    # ignores later changes - keep it last.
     include(CPack)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+    "$schema": "https://json.schemastore.org/cmake-presets.json",
     "version": 10,
     "cmakeMinimumRequired": {
         "major": 3,
@@ -8,9 +8,17 @@
     },
     "configurePresets": [
         {
+            "name": "base",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
             "name": "llvm-mingw-x86_64",
             "displayName": "LLVM-MinGW Windows x86-64",
             "description": "Cross-compile version.dll for Windows x86-64 from Linux (DLL only, no GUI)",
+            "inherits": "base",
             "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "toolchainFile": "${sourceDir}/cmake/toolchains/llvm_mingw.cmake",
@@ -27,6 +35,7 @@
             "name": "msvc",
             "displayName": "Microsoft Visual C++ x86-64",
             "description": "Build version.dll natively on Windows with MSVC (DLL only, no GUI)",
+            "inherits": "base",
             "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "architecture": {
@@ -47,6 +56,7 @@
             "name": "clang-windows-amd64",
             "displayName": "Clang Windows AMD64 (MSVC ABI)",
             "description": "Native Windows 64-bit version.dll using pure Clang (GNU driver, MSVC ABI) with Ninja (DLL only, no GUI)",
+            "inherits": "base",
             "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
@@ -109,7 +119,10 @@
             "name": "gui-linux-gcc-amd64",
             "displayName": "GUI Linux AMD64 (GCC)",
             "description": "Build wemod_enhancer_gui.elf natively on Linux x86-64 with GCC (GUI only, no version.dll)",
-            "inherits": "gui-base",
+            "inherits": [
+                "base",
+                "gui-base"
+            ],
             "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,9 +9,13 @@
     "configurePresets": [
         {
             "name": "base",
+            "displayName": "Base Configuration",
+            "description": "compile_commands.json, color diagnostics, verbose dependency fetch",
             "hidden": true,
             "cacheVariables": {
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_COLOR_DIAGNOSTICS": "ON",
+                "FETCHCONTENT_QUIET": "OFF"
             }
         },
         {

--- a/cmake/code_quality/clang_tidy-config.cmake
+++ b/cmake/code_quality/clang_tidy-config.cmake
@@ -1,11 +1,11 @@
 # ─── clang-tidy: static analysis ──────────────────────────────────
 # Two integration modes:
-#   1. Co-compilation  — CMAKE_CXX_CLANG_TIDY (Makefiles/Ninja only)
+#   1. Co-compilation  — CMAKE_<LANG>_CLANG_TIDY (Makefiles/Ninja only)
 #   2. Standalone      — run-clang-tidy wrapper target (any generator)
 #
 # Both use compile_commands.json so clang-tidy sees the *real*
-# compiler flags. Settings live in .clang-tidy (YAML), not on the
-# command line.
+# compiler flags, not a hardcoded -std=c++20.
+# Settings live in .clang-tidy (YAML), not on the command line.
 
 find_program(
     clang_tidy_exe
@@ -13,22 +13,35 @@ find_program(
     DOC "clang-tidy static analyzer" OPTIONAL)
 
 if(clang_tidy_exe)
+    # ── compile_commands.json ──────────────────────────────────────
     # Negligible cost, enables all clang-based tools.
     set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
-    # -p ${CMAKE_BINARY_DIR}: point clang-tidy at the compilation
-    # database so it resolves the correct toolchain headers.
-    set(CMAKE_CXX_CLANG_TIDY
-        "${clang_tidy_exe}" -p "${CMAKE_BINARY_DIR}"
-        CACHE STRING "clang-tidy co-compilation command")
+    # ── Co-compilation (per-file, during build) ────────────────────
+    # -p ${CMAKE_BINARY_DIR}: the generator runs clang-tidy without
+    # appending `-- <compile flags>` - the tool resolves the real
+    # flags from the compilation database itself.
+    # Ref: Professional CMake §32.1.1
+    # The project enables both C and CXX - lint both.
+    foreach(lang IN ITEMS C CXX)
+        set(CMAKE_${lang}_CLANG_TIDY
+            "${clang_tidy_exe}" -p "${CMAKE_BINARY_DIR}"
+            CACHE STRING "clang-tidy co-compilation command")
+    endforeach()
 
-    # Generated sources live in the build tree; without a .clang-tidy
-    # there they get wrong defaults when the build dir is out-of-source.
+    # ── Copy .clang-tidy into build tree ───────────────────────────
+    # Generated sources live in the build dir.  Without a
+    # .clang-tidy there, they get no settings (or wrong defaults)
+    # when the build dir is outside the source tree.
+    # configure_file works correctly even under FetchContent.
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy")
         configure_file(.clang-tidy .clang-tidy COPYONLY)
     endif()
 
-    # run-clang-tidy parallelizes across all TUs via the database.
+    # ── Standalone target (whole-project, parallel) ────────────────
+    # run-clang-tidy uses the compilation database and runs
+    # clang-tidy in parallel across all TUs — far faster than
+    # a serial custom target, and works with any generator.
     find_program(
         run_clang_tidy_exe
         NAMES run-clang-tidy run-clang-tidy.py
@@ -49,7 +62,7 @@ if(clang_tidy_exe)
             NOTICE
             "run-clang-tidy not found -- "
             "'${PROJECT_NAME}-clang-tidy' target unavailable\n"
-            "co-compilation via CMAKE_CXX_CLANG_TIDY still active")
+            "co-compilation via CMAKE_<LANG>_CLANG_TIDY still active")
     endif()
 else()
     message(

--- a/cmake/code_quality/clang_tidy-config.cmake
+++ b/cmake/code_quality/clang_tidy-config.cmake
@@ -4,8 +4,8 @@
 #   2. Standalone      — run-clang-tidy wrapper target (any generator)
 #
 # Both use compile_commands.json so clang-tidy sees the *real*
-# compiler flags, not a hardcoded -std=c++20.
-# Settings live in .clang-tidy (YAML), not on the command line.
+# compiler flags. Settings live in .clang-tidy (YAML), not on the
+# command line.
 
 find_program(
     clang_tidy_exe
@@ -13,38 +13,22 @@ find_program(
     DOC "clang-tidy static analyzer" OPTIONAL)
 
 if(clang_tidy_exe)
-    # ── compile_commands.json ──────────────────────────────────────
     # Negligible cost, enables all clang-based tools.
     set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
-    # ── Co-compilation (per-file, during build) ────────────────────
-    # -p ${CMAKE_BINARY_DIR}: since CMake 3.25 this changes how
-    # CMake constructs the clang-tidy invocation, avoiding a bug
-    # where clang-tidy finds wrong toolchain headers.
-    # Ref: Professional CMake §32.1.1
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
-        set(CMAKE_CXX_CLANG_TIDY
-            "${clang_tidy_exe}" -p "${CMAKE_BINARY_DIR}"
-            CACHE STRING "clang-tidy co-compilation command")
-    else()
-        set(CMAKE_CXX_CLANG_TIDY
-            "${clang_tidy_exe}"
-            CACHE STRING "clang-tidy co-compilation command")
-    endif()
+    # -p ${CMAKE_BINARY_DIR}: point clang-tidy at the compilation
+    # database so it resolves the correct toolchain headers.
+    set(CMAKE_CXX_CLANG_TIDY
+        "${clang_tidy_exe}" -p "${CMAKE_BINARY_DIR}"
+        CACHE STRING "clang-tidy co-compilation command")
 
-    # ── Copy .clang-tidy into build tree ───────────────────────────
-    # Generated sources live in the build dir.  Without a
-    # .clang-tidy there, they get no settings (or wrong defaults)
-    # when the build dir is outside the source tree.
-    # configure_file works correctly even under FetchContent.
+    # Generated sources live in the build tree; without a .clang-tidy
+    # there they get wrong defaults when the build dir is out-of-source.
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy")
         configure_file(.clang-tidy .clang-tidy COPYONLY)
     endif()
 
-    # ── Standalone target (whole-project, parallel) ────────────────
-    # run-clang-tidy uses the compilation database and runs
-    # clang-tidy in parallel across all TUs — far faster than
-    # a serial custom target, and works with any generator.
+    # run-clang-tidy parallelizes across all TUs via the database.
     find_program(
         run_clang_tidy_exe
         NAMES run-clang-tidy run-clang-tidy.py

--- a/cmake/code_quality/warnings-config.cmake
+++ b/cmake/code_quality/warnings-config.cmake
@@ -1,3 +1,6 @@
+# Double inclusion would error on the duplicate add_library - guard it.
+include_guard(GLOBAL)
+
 add_library(warnings INTERFACE)
 
 target_compile_options(
@@ -8,5 +11,5 @@ target_compile_options(
         "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/W4;/wd4100;/wd4505>"
         "$<$<COMPILE_LANG_AND_ID:C,MSVC>:/W4>")
 
-# 3.24+: let cmake handle -Werror / /WX portably
+# Let CMake handle -Werror / /WX portably.
 set_target_properties(warnings PROPERTIES INTERFACE_COMPILE_WARNING_AS_ERROR ON)

--- a/cmake/cpm-config.cmake
+++ b/cmake/cpm-config.cmake
@@ -17,9 +17,12 @@ include("${get_cpm_SOURCE_DIR}/CPM.cmake")
 # Enable local package reuse (vcpkg, system, etc.)
 # Ref: https://github.com/cpm-cmake/CPM.cmake#find_package-integration
 set(CPM_USE_LOCAL_PACKAGES ON)
-# set(CPM_SOURCE_CACHE "/tmp/cpm-cache")
 
-file(WRITE "${CPM_SOURCE_CACHE}/.clang-tidy" "Checks: '-*'\n")
+# Keep fetched dependency sources out of clang-tidy's reach.
+# CPM_SOURCE_CACHE is optional: without it there is no shared dir to mark.
+if(CPM_SOURCE_CACHE)
+    file(WRITE "${CPM_SOURCE_CACHE}/.clang-tidy" "Checks: '-*'\n")
+endif()
 
 set(cpm_deps_dir "${CMAKE_CURRENT_LIST_DIR}/cpm")
 

--- a/cmake/cpm-config.cmake
+++ b/cmake/cpm-config.cmake
@@ -18,8 +18,8 @@ include("${get_cpm_SOURCE_DIR}/CPM.cmake")
 # Ref: https://github.com/cpm-cmake/CPM.cmake#find_package-integration
 set(CPM_USE_LOCAL_PACKAGES ON)
 
-# Keep fetched dependency sources out of clang-tidy's reach.
-# CPM_SOURCE_CACHE is optional: without it there is no shared dir to mark.
+# Keep clang-tidy out of the dependency source cache. Guarded: the cache
+# dir only exists when CPM_SOURCE_CACHE is set (CI always sets it).
 if(CPM_SOURCE_CACHE)
     file(WRITE "${CPM_SOURCE_CACHE}/.clang-tidy" "Checks: '-*'\n")
 endif()
@@ -28,6 +28,8 @@ set(cpm_deps_dir "${CMAKE_CURRENT_LIST_DIR}/cpm")
 
 list(APPEND CMAKE_PREFIX_PATH "${cpm_deps_dir}")
 if(CMAKE_CROSSCOMPILING)
+    # Toolchains may scope find_package() to CMAKE_FIND_ROOT_PATH
+    # (CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY) — keep our configs reachable.
     list(APPEND CMAKE_FIND_ROOT_PATH "${cpm_deps_dir}")
 endif()
 

--- a/cmake/cpm/imgui-config.cmake
+++ b/cmake/cpm/imgui-config.cmake
@@ -31,10 +31,6 @@ target_include_directories(
 
 target_compile_features(imgui PUBLIC cxx_std_23)
 
-# No C++ modules anywhere: CMP0155 scanning would make GCC/Clang emit
-# -fmodule-mapper flags that the clang-tidy co-compilation rejects.
-set_target_properties(imgui PROPERTIES CXX_SCAN_FOR_MODULES OFF)
-
 # FreeType is resolved before imgui (see cmake/cpm-config.cmake). A CPM
 # build tree exports the plain `freetype` target; an installed FreeType
 # (CMake's FindFreetype module or freetype's exported config) provides
@@ -84,8 +80,6 @@ if(TARGET SDL3::SDL3)
                                                      SDL3::SDL3)
 
     target_compile_features(imgui_sdl3_renderer PUBLIC cxx_std_23)
-    set_target_properties(imgui_sdl3_renderer
-                          PROPERTIES CXX_SCAN_FOR_MODULES OFF)
 else()
     message(
         STATUS
@@ -120,8 +114,6 @@ if(TARGET SDL3::SDL3 AND TARGET OpenGL::GL)
                                                     OpenGL::GL)
 
     target_compile_features(imgui_sdl3_opengl3 PUBLIC cxx_std_23)
-    set_target_properties(imgui_sdl3_opengl3
-                          PROPERTIES CXX_SCAN_FOR_MODULES OFF)
 else()
     if(NOT TARGET SDL3::SDL3)
         message(

--- a/cmake/description/package_description-config.cmake
+++ b/cmake/description/package_description-config.cmake
@@ -106,3 +106,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             COMPONENT runtime)
     endif()
 endif()
+
+# ─── Package file naming: <os>_<compiler>_<arch> ───────────────────
+# CPACK_SYSTEM_NAME feeds CPack's default file name
+# (<name>-<version>-<system>). The compiler tag keeps native packages
+# from different toolchains apart (Linux_GNU vs Linux_Clang produced
+# identical names before); the arch tag keeps cross builds apart
+# (Windows_x86_64 vs Windows_arm64). CMake's own spellings are used
+# as-is — no case folding, no renaming (GNU stays GNU).
+set(CPACK_SYSTEM_NAME
+    "${CMAKE_SYSTEM_NAME}_${CMAKE_CXX_COMPILER_ID}_${CMAKE_SYSTEM_PROCESSOR}")

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,6 +1,11 @@
-# Dear ImGui frontend for the Python patcher CLI (opt-in via
-# WEMOD_ENHANCER_BUILD_GUI). Fully relocatable: the patcher script is
-# downloaded from the GitHub releases at runtime, never looked up on disk.
+# gui/CMakeLists.txt
+#
+# Dear ImGui frontend for the Python patcher CLI. Opt-in via
+# WEMOD_ENHANCER_BUILD_GUI (see the top-level CMakeLists.txt).
+#
+# The executable is fully relocatable: nothing in here bakes a build-
+# machine path into the binary - the patcher script is downloaded from
+# the GitHub releases at runtime, never looked up in the source tree.
 
 add_executable(wemod_enhancer_gui main.cpp)
 
@@ -11,9 +16,13 @@ target_link_libraries(
 
 target_compile_features(wemod_enhancer_gui PRIVATE cxx_std_23)
 
-# SDL_MAIN_USE_CALLBACKS is defined here, not in the source, to keep the TU
-# macro-free (cppcoreguidelines-macro-usage). The version definition makes a
-# packaged binary report exactly the project() version it was built from.
+# SDL3 app callbacks (SDL_AppInit/Iterate/Event/Quit) instead of a
+# hand-written main loop. Defined here - not as a #define in the
+# source - so the translation unit stays macro-free
+# (cppcoreguidelines-macro-usage). WEMOD_ENHANCER_GUI_VERSION rides
+# along: the GUI shows the CMake project version it was built from, so
+# a packaged binary can never report a version that differs from its
+# package.
 target_compile_definitions(
     wemod_enhancer_gui
     PRIVATE SDL_MAIN_USE_CALLBACKS=1
@@ -23,26 +32,31 @@ target_compile_definitions(
 set_target_properties(wemod_enhancer_gui PROPERTIES WIN32_EXECUTABLE TRUE
                                                     MACOSX_BUNDLE TRUE)
 
-# cpplint enforces Google style, which contradicts this project's
-# .clang-format; clang-tidy is the configured gate.
+# cpplint enforces Google style (same-line braces, no non-const refs),
+# which contradicts this project's .clang-format; clang-tidy is the
+# configured gate, so disable the cpplint co-compile for this target.
 set_target_properties(wemod_enhancer_gui PROPERTIES CXX_CPPLINT "")
 
-# Self-contained binaries: statically link the C++ runtime (and CRT) so the
-# executable runs on a bare OS install. SDL3 is already built static
-# (cmake/cpm/sdl3-config.cmake).
+# Self-contained binaries: statically link the C++ runtime (and CRT) so
+# the executable runs on a bare OS install. SDL3 is already built static
+# (see cmake/cpm/sdl3-config.cmake).
 if(MSVC)
     set_target_properties(
         wemod_enhancer_gui
         PROPERTIES MSVC_RUNTIME_LIBRARY
                    "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 elseif(MINGW)
-    # Mirrors src/CMakeLists.txt: static libc++/libgcc for llvm-mingw.
+    # Mirrors src/CMakeLists.txt: static libc++/libgcc for the
+    # llvm-mingw cross build.
     target_link_options(wemod_enhancer_gui PRIVATE -static)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Name the artifact .elf so it is unmistakable next to the Windows .exe.
+    # Name the artifact wemod_enhancer_gui.elf so the Linux binary is
+    # unmistakable next to the Windows wemod_enhancer_gui.exe.
     set_target_properties(wemod_enhancer_gui PROPERTIES SUFFIX ".elf")
     # Static libstdc++/libgcc only when the toolchain ships the static
-    # archives (debian: libstdc++-*-dev, fedora: libstdc++-static).
+    # archives (Debian: libstdc++-*-dev, Fedora: libstdc++-static).
+    # Otherwise fall back to the system libstdc++, which every base
+    # install has - SDL3 stays static either way.
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag("-static-libstdc++ -static-libgcc"
                             have_static_cxx_runtime)
@@ -58,4 +72,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
 endif()
 
+# Standalone install rule (the GUI presets are mutually exclusive with
+# the version.dll ones - see the top-level CMakeLists.txt). Explicit
+# GNUInstallDirs destination: bin/ on every platform.
 install(TARGETS wemod_enhancer_gui RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,11 +1,6 @@
-# gui/CMakeLists.txt
-#
-# Dear ImGui frontend for the Python patcher CLI. Opt-in via
-# WEMOD_ENHANCER_BUILD_GUI (see the top-level CMakeLists.txt).
-#
-# The executable is fully relocatable: nothing in here bakes a build-
-# machine path into the binary - the patcher script is downloaded from
-# the GitHub releases at runtime, never looked up in the source tree.
+# Dear ImGui frontend for the Python patcher CLI (opt-in via
+# WEMOD_ENHANCER_BUILD_GUI). Fully relocatable: the patcher script is
+# downloaded from the GitHub releases at runtime, never looked up on disk.
 
 add_executable(wemod_enhancer_gui main.cpp)
 
@@ -16,13 +11,9 @@ target_link_libraries(
 
 target_compile_features(wemod_enhancer_gui PRIVATE cxx_std_23)
 
-# SDL3 app callbacks (SDL_AppInit/Iterate/Event/Quit) instead of a
-# hand-written main loop. Defined here - not as a #define in the
-# source - so the translation unit stays macro-free
-# (cppcoreguidelines-macro-usage). WEMOD_ENHANCER_GUI_VERSION rides
-# along: the GUI shows the CMake project version it was built from, so
-# a packaged binary can never report a version that differs from its
-# package.
+# SDL_MAIN_USE_CALLBACKS is defined here, not in the source, to keep the TU
+# macro-free (cppcoreguidelines-macro-usage). The version definition makes a
+# packaged binary report exactly the project() version it was built from.
 target_compile_definitions(
     wemod_enhancer_gui
     PRIVATE SDL_MAIN_USE_CALLBACKS=1
@@ -32,35 +23,26 @@ target_compile_definitions(
 set_target_properties(wemod_enhancer_gui PROPERTIES WIN32_EXECUTABLE TRUE
                                                     MACOSX_BUNDLE TRUE)
 
-# No C++ modules: CMP0155 would add -fmodule-mapper flags that the
-# clang-tidy co-compilation (CXX_CLANG_TIDY) does not understand.
-set_target_properties(wemod_enhancer_gui PROPERTIES CXX_SCAN_FOR_MODULES OFF)
-
-# cpplint enforces Google style (same-line braces, no non-const refs),
-# which contradicts this project's .clang-format; clang-tidy is the
-# configured gate, so disable the cpplint co-compile for this target.
+# cpplint enforces Google style, which contradicts this project's
+# .clang-format; clang-tidy is the configured gate.
 set_target_properties(wemod_enhancer_gui PROPERTIES CXX_CPPLINT "")
 
-# Self-contained binaries: statically link the C++ runtime (and CRT) so
-# the executable runs on a bare OS install. SDL3 is already built static
-# (see cmake/cpm/sdl3-config.cmake).
+# Self-contained binaries: statically link the C++ runtime (and CRT) so the
+# executable runs on a bare OS install. SDL3 is already built static
+# (cmake/cpm/sdl3-config.cmake).
 if(MSVC)
     set_target_properties(
         wemod_enhancer_gui
         PROPERTIES MSVC_RUNTIME_LIBRARY
                    "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 elseif(MINGW)
-    # Mirrors src/CMakeLists.txt: static libc++/libgcc for the
-    # llvm-mingw cross build.
+    # Mirrors src/CMakeLists.txt: static libc++/libgcc for llvm-mingw.
     target_link_options(wemod_enhancer_gui PRIVATE -static)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Name the artifact wemod_enhancer_gui.elf so the Linux binary is
-    # unmistakable next to the Windows wemod_enhancer_gui.exe.
+    # Name the artifact .elf so it is unmistakable next to the Windows .exe.
     set_target_properties(wemod_enhancer_gui PROPERTIES SUFFIX ".elf")
     # Static libstdc++/libgcc only when the toolchain ships the static
-    # archives (Debian: libstdc++-*-dev, Fedora: libstdc++-static).
-    # Otherwise fall back to the system libstdc++, which every base
-    # install has - SDL3 stays static either way.
+    # archives (debian: libstdc++-*-dev, fedora: libstdc++-static).
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag("-static-libstdc++ -static-libgcc"
                             have_static_cxx_runtime)
@@ -76,8 +58,4 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
 endif()
 
-# Standalone install rule (the GUI presets are mutually exclusive with
-# the version.dll ones - see the top-level CMakeLists.txt). Explicit
-# GNUInstallDirs destination: bin/ on every platform.
-include(GNUInstallDirs)
 install(TARGETS wemod_enhancer_gui RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,21 +1,19 @@
-add_library(version SHARED fuses.c library.c library.def)
+add_library(version SHARED)
+target_sources(version PRIVATE fuses.c library.c library.def)
+
+target_compile_features(version PRIVATE c_std_11)
 
 set_target_properties(
     version
     PROPERTIES PREFIX ""
-               OUTPUT_NAME "version"
                MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-target_compile_features(version PRIVATE c_std_11)
-
-# MinGW-Clang needs -static to link static libgcc; MSVC-ABI Clang uses
-# MSVC_RUNTIME_LIBRARY (above) for static CRT and does not understand -static
-# the same way through lld-link.
-if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND NOT CMAKE_C_COMPILER_TARGET MATCHES "msvc")
+# MinGW (LLVM-MinGW cross): link the GCC runtime statically so the DLL is
+# self-contained. MSVC-ABI Clang takes MSVC_RUNTIME_LIBRARY above instead.
+if(MINGW)
     target_link_options(version PRIVATE -static)
 endif()
 
-include(GNUInstallDirs)
 install(
     TARGETS version
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,17 @@
-add_library(version SHARED)
-target_sources(version PRIVATE fuses.c library.c library.def)
-
-target_compile_features(version PRIVATE c_std_11)
+add_library(version SHARED fuses.c library.c library.def)
 
 set_target_properties(
     version
     PROPERTIES PREFIX ""
+               OUTPUT_NAME "version"
                MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-# MinGW (LLVM-MinGW cross): link the GCC runtime statically so the DLL is
-# self-contained. MSVC-ABI Clang takes MSVC_RUNTIME_LIBRARY above instead.
-if(MINGW)
+target_compile_features(version PRIVATE c_std_11)
+
+# MinGW-Clang needs -static to link static libgcc; MSVC-ABI Clang uses
+# MSVC_RUNTIME_LIBRARY (above) for static CRT and does not understand -static
+# the same way through lld-link.
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND NOT CMAKE_C_COMPILER_TARGET MATCHES "msvc")
     target_link_options(version PRIVATE -static)
 endif()
 


### PR DESCRIPTION
# Pull Request

## Summary
Sync the build system with [cmake_template](https://github.com/e-gleba/cmake_template)'s logic as surgical diffs: no file rewrites, original comments and structure preserved, only template-proven changes applied on the CMake 3.31 floor.

## Related Issue
No issue — build-system maintenance.

## Changes

**`CMakeLists.txt`** (5 surgical edits, everything else byte-identical)
- `set(CMAKE_CXX_SCAN_FOR_MODULES OFF)` after `project()` — template-exact; no C++ modules in use, so skip the dependency scan on every target.
- `if(WIN32 …)` → `if(CMAKE_SYSTEM_NAME STREQUAL "Windows" …)` — explicit target-system gate, same semantics for native and llvm-mingw cross builds.
- `include(GNUInstallDirs)` moved to the root, unconditional, right before `add_subdirectory(src)` — template placement; removes the need for the per-directory includes in `src/` and `gui/`.
- Removed dead `PROJECT_VENDOR` / `PROJECT_CONTACT` / `PROJECT_LICENSE_FILE` / `PROJECT_README_FILE` — template logic keeps these in the packaging module, and `package_description-config.cmake` already re-sets all four unconditionally (with a different contact email), so the root copies never took effect.
- Removed the root `string(APPEND CPACK_SYSTEM_NAME …)` block — see fix below.

**`cmake/description/package_description-config.cmake`**
- Now owns `CPACK_SYSTEM_NAME` as `"${CMAKE_SYSTEM_NAME}_${CMAKE_CXX_COMPILER_ID}_${CMAKE_SYSTEM_PROCESSOR}"` — template `ct_cpack` logic, comment included. **Fixes a real bug:** the old root `string(APPEND CPACK_SYSTEM_NAME …)` ran before `include(CPack)` while the variable was still undefined, so packages were named `wemod_enhancer-1.0.5--x86_64.zip` (double dash, no OS) — CPack skips its default once the variable is defined. New names: `wemod_enhancer-1.0.5-Windows_Clang_x86_64.tar.xz`, `…-Windows_MSVC_AMD64.zip`, `wemod_enhancer_gui-1.0.5-Linux_GNU_aarch64.tar.xz`, etc.

**`cmake/code_quality/clang_tidy-config.cmake`**
- Dropped the dead `CMAKE_VERSION >= 3.25` fallback branch (floor is 3.31; the `-p` form is always used).
- Lint C and CXX via the template's `foreach(lang IN ITEMS C CXX)` loop — the DLL is pure C and escaped tidy entirely. Safe: `.clang-tidy` sets no `WarningsAsErrors`, and the llvm-mingw toolchain already force-clears both `CMAKE_C_CLANG_TIDY` and `CMAKE_CXX_CLANG_TIDY`.

**`cmake/code_quality/warnings-config.cmake`** — `include_guard(GLOBAL)` from template `ct_warnings` (double `find_package` would error on the duplicate `add_library`).

**`cmake/cpm-config.cmake`** — template-exact guard for the `.clang-tidy` cache stamp (`if(CPM_SOURCE_CACHE)`; previously wrote to `/.clang-tidy` when unset), template's comment inside the cross-compiling block, dropped the stale commented-out `CPM_SOURCE_CACHE` line.

**`cmake/cpm/imgui-config.cmake`, `gui/CMakeLists.txt`** — removed the per-target `CXX_SCAN_FOR_MODULES OFF` blocks (covered by the root global set; the template's imgui config relies on the global too) and the duplicate `include(GNUInstallDirs)`. All other content byte-identical.

**`src/CMakeLists.txt`** — removed only the `include(GNUInstallDirs)` line (root covers it now).

**`CMakePresets.json`**
- `$schema` → `https://json.schemastore.org/cmake-presets.json` (matches template; Kitware's `_downloads/` URLs change per patch release).
- Hidden `base` configure preset with `CMAKE_EXPORT_COMPILE_COMMANDS=ON`, `CMAKE_COLOR_DIAGNOSTICS=ON`, `FETCHCONTENT_QUIET=OFF` (template base's cache variables), inherited by the four root presets, transitively by the rest. Schema `version` stays 10 — the maximum CMake 3.31 reads.

## Verification
- [ ] `cmake --workflow --preset llvm-mingw-x86_64-full` — CI `cross-windows` job
- [ ] `cmake --workflow --preset msvc-full` / `clang-windows-amd64-full` — CI `native` job
- [ ] GUI matrix (`gui-windows-*`, `gui-linux-*`) — CI `gui.yml`
- [ ] `pre-commit run --all-files` passes

Left unchecked on purpose: this PR's CI run is the verification.

## Notes for Reviewer
- Package file names change (bug fix above). CI rename steps glob `*.zip` / `*.tar.xz`, so workflows and release asset names are unaffected.
- Deliberate deviations from template logic, left for follow-up PRs:
  - `warnings` is still not linked into `version` / `wemod_enhancer_gui` — the template links it `PRIVATE` into every first-party target, but that turns on `-Werror` / `/WX` + `-Wconversion` on a 62 KB imgui TU; needs its own PR with CI soak.
  - `cmake/toolchains/llvm_mingw.cmake` diverged from the template's (newer `LLVM_MINGW_VERSION` 20260616, optional `LLVM_MINGW_TARBALL_SHA256` pin) — Renovate territory, not this PR.
  - Template generates the CPack long description via `file(CONFIGURE)` from `project()` metadata; wemod keeps its hand-written `description.txt` — content change, not logic, so untouched.
  - Module mechanics stay `find_package(... CONFIG REQUIRED)` (wemod's own evolution) rather than the template's `CMAKE_MODULE_PATH` + `include(ct_*)` — renaming would be a rewrite, not a sync.