### PR TITLE
chore(deps): update microsoft/GSL to 4.2.2

### DIFF
--- a/cmake/cpm/gsl-config.cmake
+++ b/cmake/cpm/gsl-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     microsoft/GSL
     GIT_TAG
-    v4.2.1
+    4.2.2
     GIT_SHALLOW
     TRUE
     GIT_PROGRESS


### PR DESCRIPTION
Bump microsoft/GSL v4.2.1 → v4.2.2 (linked by the GUI).

No issue — Renovate branch, no PR was opened (awaiting schedule).

GSL 5.0.0 is a separate major; not included.