### PR TITLE
chore(deps): update lua/lua to 5.5.1

### DIFF
--- a/cmake/cpm/lua_lang-config.cmake
+++ b/cmake/cpm/lua_lang-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     lua/lua
     VERSION
-    5.5.0
+    5.5.1
     EXCLUDE_FROM_ALL
     ON
     DOWNLOAD_ONLY


### PR DESCRIPTION
Bump lua/lua 5.5.0 → 5.5.1.

Unused by this project (cmake-template leftover). Pin-only bump so Renovate is current.

No issue — Renovate branch, no PR was opened (awaiting schedule).