### PR TITLE
chore(deps): update SanderMertens/flecs to 4.1.6

### DIFF
--- a/cmake/cpm/flecs-config.cmake
+++ b/cmake/cpm/flecs-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     SanderMertens/flecs
     VERSION
-    4.1.5
+    4.1.6
     GIT_TAG
     v4.1.5
     GIT_SHALLOW


### PR DESCRIPTION
Bump SanderMertens/flecs 4.1.5 → 4.1.6.

Unused by this project (cmake-template leftover). Pin-only bump so Renovate is current.

No issue — Renovate branch, no PR was opened (awaiting schedule).