### PR TITLE
chore(deps): update lua/lua to 5.5.1

### DIFF
--- a/cmake/cpm/lua_lang-config.cmake
+++ b/cmake/cpm/lua_lang-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GIT_REPOSITORY
     https://github.com/lua/lua.git
     VERSION
-    5.5.0
+    5.5.1
     DOWNLOAD_ONLY
     YES)
 


### PR DESCRIPTION
Bump lua/lua 5.5.0 → 5.5.1. Version pin only — Renovate's own branch rewrote the CMake file, so this is a surgical replacement.

Unused by this project (cmake-template leftover).

No issue — dep pin.