### PR TITLE
fix(gui): static-link C++ runtime on llvm-mingw builds (Proton)

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -16,7 +16,7 @@ set_target_properties(
 target_link_options(
     wemod_enhancer_gui
     PRIVATE
-    "$<$<AND:$<PLATFORM_ID:Windows>,$<LINK_LANG_AND_ID:CXX,GNU>>:-static>"
+    "$<$<AND:$<PLATFORM_ID:Windows>,$<LINK_LANG_AND_ID:CXX,GNU,Clang>>:-static>"
     "$<$<PLATFORM_ID:Linux>:-static-libstdc++;-static-libgcc>")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")


### PR DESCRIPTION
# Pull Request

## Summary
Make the llvm-mingw cross-built Windows GUI launch under Proton/Steam Deck by static-linking the C++ runtime (it currently dies before showing a window).

## Related Issue
No issue — user report: "msvc gui works on steam proton, llvm mingw not".

## Changes
**One line in `src/gui/CMakeLists.txt`:** add `Clang` to the `$<LINK_LANG_AND_ID:CXX,GNU,Clang>` compiler-id list guarding the Windows `-static` link option.

### Root cause
The `windows_llvm_mingw_amd64` preset drives `x86_64-w64-mingw32-clang++`, whose CMake compiler ID is **Clang**, not GNU. The generator expression `$<LINK_LANG_AND_ID:CXX,GNU>` therefore evaluated to `0` and `-static` was silently dropped from the link line. llvm-mingw defaults to **shared** libc++/libunwind runtimes, so the exe ended up importing `libc++.dll` and `libunwind.dll` ([mstorsjo/llvm-mingw#525](https://github.com/mstorsjo/llvm-mingw/issues/525)). The package ships only `exe + wemod_enhancer.py + version.dll`, and a stock Proton prefix contains neither DLL — so the Windows loader terminated the process before `SDL_AppInit` ever ran. The MSVC build was unaffected because `/MT` (via the `MSVC_RUNTIME_LIBRARY MultiThreaded` property already on the target) statically links its CRT.

### Why adding `Clang` is safe for the other Windows preset
The native `windows_clang_amd64` preset (GNU-driver Clang, MSVC ABI) also now matches. For `*-pc-windows-msvc` targets the GNU driver maps `-static` to static-CRT selection — the same thing `MSVC_RUNTIME_LIBRARY MultiThreaded` already requests on this target, so the flag agrees with (rather than fights) the existing configuration. Linux branches are untouched (`PLATFORM_ID:Windows` guard).

## Verification
- [x] `cmake --workflow --preset windows_llvm_mingw_amd64_full` passes (CI: cross-windows job on this PR)
- [x] `cmake --workflow --preset windows_msvc_amd64_full` passes (CI: native job — untouched path)
- [x] `cmake --workflow --preset windows_clang_amd64_full` passes (CI: native Clang job — new `-static` match)
- [x] `cmake --workflow --preset linux_gcc_amd64_full` passes (CI — untouched path)
- [ ] post-merge release check: `llvm-objdump -p wemod_enhancer_gui.exe | grep -i "DLL Name"` shows **no** `libc++.dll`/`libunwind.dll` imports, and the exe starts under `proton run` / Steam Deck

## Notes for Reviewer
- No source-code changes, no preset/toolchain changes — the diff is a single compiler-id addition.
- Alternative considered: bundling `libc++.dll`/`libunwind.dll` into the package via CPack — rejected: bigger packages, version-coupled DLLs, and the readme's contract is a *self-contained movable folder*; the MSVC build already sets that bar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build compatibility by enabling static linking for both GNU and Clang toolchains.
  * Linux static library linking remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->