### PR TITLE
gui: larger adaptive window, path+browse, equal-width actions

### DIFF
--- a/cmake/cpm/imgui-config.cmake
+++ b/cmake/cpm/imgui-config.cmake
@@ -2,7 +2,7 @@ cpmaddpackage(
     NAME
     imgui
     VERSION
-    1.92.9
+    1.92.9b
     GITHUB_REPOSITORY
     ocornut/imgui
     EXCLUDE_FROM_ALL

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -33,7 +33,8 @@
 //   - Status line, then Settings as a collapsing header (collapsed
 //     by default, full width - Python / patcher / version.dll).
 //   - Log fills the rest. Copy output / Report bug share one
-//     equal-width full-span row; version pinned right under it.
+//     equal-width full-span row; Copied! left and version right on
+//     the footer line under it.
 //   - Window size is a fraction of the usable display (clamped) so
 //     FHD / 1440p / 4K all open comfortably; FontScaleDpi scales
 //     every font-size-derived widget.
@@ -1155,7 +1156,7 @@ void draw_ui(app_state& state)
     }
     ImGui::EndChild();
 
-    // --- Bottom toolbar: Copy / Report equal-width, version right -----
+    // --- Bottom toolbar: Copy / Report equal-width --------------------
     ImGui::Spacing();
     const float util_w{equal_button_width(2)};
     if (action_button("Copy output", util_w, util_h)) {
@@ -1172,16 +1173,20 @@ void draw_ui(app_state& state)
         tooltip_text("Open a pre-filled GitHub issue with the log attached");
     }
 
+    // Footer under the full-span row: Copied! left, version right.
+    // Copy/Report already ate the row - SameLine onto it would clip.
+    ImGui::Spacing();
+    const float footer_y{ImGui::GetCursorPosY()};
     if (state.copied_flash > 0.0F) {
         state.copied_flash -= ImGui::GetIO().DeltaTime;
         text_colored(color_ok, "Copied!");
-        ImGui::SameLine();
     }
     {
         const std::string version_text{std::format("v{}", gui_version)};
         const float text_width{ImGui::CalcTextSize(version_text.c_str()).x};
-        ImGui::SameLine(ImGui::GetContentRegionAvail().x +
-                        ImGui::GetCursorPosX() - text_width);
+        ImGui::SetCursorPos(
+            ImVec2(ImGui::GetWindowContentRegionMax().x - text_width,
+                   footer_y));
         ImGui::TextDisabled("%s", version_text.c_str());
         if (ImGui::IsItemHovered()) {
             tooltip_text(std::string(SDL_GetPlatform()) + " " +

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -32,9 +32,10 @@
 //     so every full-span row reads as one control language.
 //   - Status line, then Settings as a collapsing header (collapsed
 //     by default, full width - Python / patcher / version.dll).
-//   - Log fills the rest. Copy output / Clear output / Report bug
-//     share one equal-width full-span row; Copied! left and the
-//     version centered on the footer line under it.
+//   - Console section: muted label, then the log filling the rest.
+//     Copy output / Clear output / Report bug share one equal-width
+//     full-span row; Copied! left and the version centered on the
+//     footer line under it.
 //   - Window size is a fraction of the usable display (clamped) so
 //     FHD / 1440p / 4K all open comfortably; FontScaleDpi scales
 //     every font-size-derived widget.
@@ -1133,10 +1134,16 @@ void draw_ui(app_state& state)
         ImGui::Unindent();
     }
 
-    // --- Log: fills the rest of the window ----------------------------
+    // --- Console: live stdout/stderr, fills the rest of the window ----
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
+
+    field_label("Console");
+    help_marker(
+        "Live stdout and stderr from the patcher, the Python probe, "
+        "and Download WeMod. Copy it below if something fails.",
+        "https://github.com/e-gleba/wemod_enhancer/issues/new");
 
     const float line_height{ImGui::GetTextLineHeightWithSpacing()};
     const float toolbar_h{row_h + line_height + (style.ItemSpacing.y * 3.0F)};

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -28,8 +28,8 @@
 //   - WeMod folder field with Browse on the same row.
 //   - Full-width action row under the path: Patch / Restore, plus
 //     Download WeMod only while the folder is unresolved. Buttons
-//     share the row equally and use a taller frame so they are easy
-//     hit targets at any DPI.
+//     share the row equally. Same height as Copy / Clear / Report
+//     so every full-span row reads as one control language.
 //   - Status line, then Settings as a collapsing header (collapsed
 //     by default, full width - Python / patcher / version.dll).
 //   - Log fills the rest. Copy output / Clear output / Report bug
@@ -194,12 +194,10 @@ constexpr std::int32_t window_max_height{1050};
 constexpr float button_padding{24.0F};
 constexpr float section_indent{16.0F};
 
-// Action row (Patch / Restore / Download): taller than the default
-// frame so they are easy hit targets. Utility row (Copy / Clear /
-// Report) is a step down - still large, not competing with Patch.
+// One height for every full-span button row (Patch / Restore and
+// Copy / Clear / Report). Same scale = one control language.
 // Font-size derived via GetFrameHeight().
-constexpr float action_height_scale{2.0F};
-constexpr float util_height_scale{1.55F};
+constexpr float row_height_scale{1.55F};
 
 constexpr ImVec4 clear_color{0.10F, 0.10F, 0.12F, 1.00F};
 
@@ -1009,6 +1007,7 @@ void draw_ui(app_state& state)
     ImGui::Begin("##main", nullptr, window_flags);
 
     const ImGuiStyle& style{ImGui::GetStyle()};
+    const float row_h{ImGui::GetFrameHeight() * row_height_scale};
 
     probe_filesystem(state);
     const fs::path& resolved_dir{state.resolved_install_dir};
@@ -1064,16 +1063,16 @@ void draw_ui(app_state& state)
     // --- Actions: equal-width row, full span under the path -----------
     // Count = 2 (Patch, Restore) or 3 (+ Download WeMod while the
     // folder is unresolved). Every button gets the same slice so the
-    // row is one alignment axis, whatever the labels.
+    // row is one alignment axis, whatever the labels. Height matches
+    // the Copy / Clear / Report row below.
     ImGui::Spacing();
     const int action_count{install_ok ? 2 : 3};
     const float action_w{equal_button_width(action_count)};
-    const float action_h{ImGui::GetFrameHeight() * action_height_scale};
 
     const char* block_reason{patch_block_reason(install_ok, script_ok)};
     const bool blocked{state.running || block_reason != nullptr};
     ImGui::BeginDisabled(blocked);
-    if (action_button("Patch", action_w, action_h)) {
+    if (action_button("Patch", action_w, row_h)) {
         // Normalize the field to the resolved dir: the log then shows
         // the exact folder the patcher ran against.
         state.install_dir = resolved_dir.string();
@@ -1087,14 +1086,14 @@ void draw_ui(app_state& state)
 
     ImGui::SameLine();
     ImGui::BeginDisabled(state.running);
-    if (action_button("Restore", action_w, action_h)) {
+    if (action_button("Restore", action_w, row_h)) {
         start_run(state, "restore");
     }
     ImGui::EndDisabled();
 
     if (!install_ok) {
         ImGui::SameLine();
-        if (action_button("Download WeMod", action_w, action_h)) {
+        if (action_button("Download WeMod", action_w, row_h)) {
             start_wemod_download(state);
         }
         if (ImGui::IsItemHovered()) {
@@ -1140,8 +1139,7 @@ void draw_ui(app_state& state)
     ImGui::Spacing();
 
     const float line_height{ImGui::GetTextLineHeightWithSpacing()};
-    const float util_h{ImGui::GetFrameHeight() * util_height_scale};
-    const float toolbar_h{util_h + line_height + (style.ItemSpacing.y * 3.0F)};
+    const float toolbar_h{row_h + line_height + (style.ItemSpacing.y * 3.0F)};
     const float log_height{std::max(ImGui::GetContentRegionAvail().y - toolbar_h,
                                     line_height * 4.0F)};
 
@@ -1167,7 +1165,7 @@ void draw_ui(app_state& state)
     // --- Bottom toolbar: Copy / Clear / Report, equal-width -----------
     ImGui::Spacing();
     const float util_w{equal_button_width(3)};
-    if (action_button("Copy output", util_w, util_h)) {
+    if (action_button("Copy output", util_w, row_h)) {
         copy_output(state);
     }
     if (ImGui::IsItemHovered()) {
@@ -1175,7 +1173,7 @@ void draw_ui(app_state& state)
     }
     ImGui::SameLine();
     ImGui::BeginDisabled(state.log.empty());
-    if (action_button("Clear output", util_w, util_h)) {
+    if (action_button("Clear output", util_w, row_h)) {
         clear_output(state);
     }
     ImGui::EndDisabled();
@@ -1183,7 +1181,7 @@ void draw_ui(app_state& state)
         tooltip_text("Clear the log");
     }
     ImGui::SameLine();
-    if (action_button("Report bug", util_w, util_h)) {
+    if (action_button("Report bug", util_w, row_h)) {
         report_bug(state);
     }
     if (ImGui::IsItemHovered()) {
@@ -1202,9 +1200,10 @@ void draw_ui(app_state& state)
         const float text_width{ImGui::CalcTextSize(version_text.c_str()).x};
         const float content_min{ImGui::GetWindowContentRegionMin().x};
         const float content_max{ImGui::GetWindowContentRegionMax().x};
-        ImGui::SetCursorPos(ImVec2(
-            content_min + ((content_max - content_min) - text_width) * 0.5F,
-            footer_y));
+        const float content_span{content_max - content_min};
+        const float version_x{content_min +
+                              ((content_span - text_width) * 0.5F)};
+        ImGui::SetCursorPos(ImVec2(version_x, footer_y));
         text_disabled(version_text);
         if (ImGui::IsItemHovered()) {
             tooltip_text(std::string(SDL_GetPlatform()) + " " +

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -23,17 +23,17 @@
 // Structure: SDL3 app callbacks (SDL_MAIN_USE_CALLBACKS is set via
 // CMake), one frame = poll the background command + draw the UI.
 //
-// Layout (default imgui theme, untouched - hierarchy comes from
-// alignment and scale, not colors):
-//   - Top toolbar: Settings opens a floating window (Python,
-//     patcher, version.dll); the build version is pinned right.
+// Layout (default imgui theme, untouched colors - hierarchy comes
+// from alignment, padding and scale):
 //   - WeMod folder field with Browse on the same row.
 //   - Full-width action row under the path: Patch / Restore, plus
-//     Download WeMod only while the folder is unresolved. The
-//     buttons share the row equally and use a taller frame so they
-//     are easy hit targets at any DPI.
-//   - Status line, then the log filling the rest, then Copy output
-//     / Report bug on the bottom toolbar.
+//     Download WeMod only while the folder is unresolved. Buttons
+//     share the row equally and use a taller frame so they are easy
+//     hit targets at any DPI.
+//   - Status line, then Settings as a collapsing header (collapsed
+//     by default, full width - Python / patcher / version.dll).
+//   - Log fills the rest. Copy output / Report bug share one
+//     equal-width full-span row; version pinned right under it.
 //   - Window size is a fraction of the usable display (clamped) so
 //     FHD / 1440p / 4K all open comfortably; FontScaleDpi scales
 //     every font-size-derived widget.
@@ -179,22 +179,25 @@ constexpr std::string_view default_python{
 // 1440p / 4K all get a comfortable default; FontScaleDpi then scales
 // every font-size-derived widget. SDL keeps the physical size
 // constant across DPIs because the window is created at logical size.
-constexpr std::int32_t window_width_fallback{960};
-constexpr std::int32_t window_height_fallback{640};
-constexpr std::int32_t window_min_width{800};
-constexpr std::int32_t window_min_height{560};
-constexpr std::int32_t window_max_width{1600};
-constexpr std::int32_t window_max_height{1000};
-constexpr std::int32_t log_lines_reserved{8};
+constexpr std::int32_t window_width_fallback{1024};
+constexpr std::int32_t window_height_fallback{680};
+constexpr std::int32_t window_min_width{880};
+constexpr std::int32_t window_min_height{600};
+constexpr std::int32_t window_max_width{1680};
+constexpr std::int32_t window_max_height{1050};
 
 // Extra horizontal padding on the Browse button so it matches the
 // path field's visual weight. Action buttons ignore this - they
 // stretch to share the full row.
 constexpr float button_padding{24.0F};
+constexpr float section_indent{16.0F};
 
-// Action row: taller than the default frame so Patch / Restore are
-// easy hit targets. Font-size derived via GetFrameHeight().
-constexpr float action_height_scale{1.8F};
+// Action row (Patch / Restore / Download): taller than the default
+// frame so they are easy hit targets. Utility row (Copy / Report)
+// is a step down - still large, not competing with Patch.
+// Font-size derived via GetFrameHeight().
+constexpr float action_height_scale{2.0F};
+constexpr float util_height_scale{1.55F};
 
 constexpr ImVec4 clear_color{0.10F, 0.10F, 0.12F, 1.00F};
 
@@ -238,7 +241,6 @@ struct app_state final
     bool has_run{false};
     std::int32_t last_exit_code{0};
     float copied_flash{0.0F}; // seconds left of "Copied!" feedback
-    bool settings_open{false}; // floating Settings window
     // --- filesystem probe cache (see probe_filesystem) ---
     std::string probed_install_dir; // field text the last resolve ran on
     std::string probed_script_path; // ditto, for the script probe
@@ -855,8 +857,8 @@ void report_bug(app_state& state)
 
 // --- layout helpers (font-size derived, DPI-correct) ------------------
 
-// Action / Browse button at an explicit size. Height 0 keeps the
-// default frame height (path row). Returns true when clicked.
+// Button at an explicit size. Height 0 keeps the default frame
+// height (path-row Browse). Returns true when clicked.
 bool action_button(const char* label, const float width, const float height)
 {
     Expects(label != nullptr);
@@ -864,7 +866,8 @@ bool action_button(const char* label, const float width, const float height)
 }
 
 // Equal slice of the current row for `count` sibling buttons, gaps
-// included. Stretch-to-fill: the action row always spans the window.
+// included. Stretch-to-fill: action and utility rows always span
+// the window.
 [[nodiscard]] float equal_button_width(const int count)
 {
     Expects(count > 0);
@@ -872,19 +875,6 @@ bool action_button(const char* label, const float width, const float height)
     const float avail{ImGui::GetContentRegionAvail().x};
     const float gaps{style.ItemSpacing.x * static_cast<float>(count - 1)};
     return std::max((avail - gaps) / static_cast<float>(count), 1.0F);
-}
-
-// Small utility button sized to its label, for the toolbar rows
-// where buttons sit in one horizontal row. Returns true when clicked.
-bool fit_button(const char* label)
-{
-    Expects(label != nullptr);
-    const ImGuiStyle& style{ImGui::GetStyle()};
-    const ImVec2 text{ImGui::CalcTextSize(label)};
-    return ImGui::Button(
-        label,
-        ImVec2(text.x + style.FramePadding.x * 2.0F,
-               text.y + style.FramePadding.y * 2.0F));
 }
 
 // Small dim section label above a field.
@@ -945,12 +935,9 @@ void help_marker(const char* text, const char* url)
     return {};
 }
 
-// Floating Settings window body: patcher / Python / version.dll.
-// Inputs stretch to the window; Dummy below sets a DPI-safe min width.
+// Settings body: patcher / Python / version.dll. Inputs stretch.
 void draw_settings(app_state& state, const bool script_ok)
 {
-    ImGui::Dummy(ImVec2(ImGui::GetFontSize() * 34.0F, 0.0F));
-
     field_label("Patcher");
     help_marker(
         "wemod_enhancer.py + version.dll ship inside this package, "
@@ -996,9 +983,9 @@ void draw_settings(app_state& state, const bool script_ok)
                              &state.version_dll);
 }
 
-// The whole window: toolbar, path+Browse, equal-width action row,
-// status, scrolling log, bottom utilities. Settings is a floating
-// window opened from the toolbar. One frame = one draw call.
+// The whole window: path+Browse, equal-width action row, status,
+// collapsing Settings, scrolling log, equal-width Copy/Report.
+// One frame = one draw call.
 void draw_ui(app_state& state)
 {
     const ImGuiViewport* viewport{ImGui::GetMainViewport()};
@@ -1018,29 +1005,6 @@ void draw_ui(app_state& state)
     const fs::path& resolved_dir{state.resolved_install_dir};
     const bool install_ok{!resolved_dir.empty()};
     const bool script_ok{state.script_present};
-
-    // --- Toolbar: Settings (floating window) + version ----------------
-    if (fit_button("Settings")) {
-        state.settings_open = true;
-    }
-    if (ImGui::IsItemHovered()) {
-        tooltip_text("Python, patcher path, version.dll");
-    }
-    {
-        const std::string version_text{std::format("v{}", gui_version)};
-        const float text_width{ImGui::CalcTextSize(version_text.c_str()).x};
-        ImGui::SameLine(ImGui::GetContentRegionAvail().x +
-                        ImGui::GetCursorPosX() - text_width);
-        ImGui::TextDisabled("%s", version_text.c_str());
-        if (ImGui::IsItemHovered()) {
-            tooltip_text(std::string(SDL_GetPlatform()) + " " +
-                         std::string(target_arch));
-        }
-    }
-
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
 
     // --- WeMod folder + Browse on one row -----------------------------
     // Validity is an invariant of the current field text, re-probed on
@@ -1150,16 +1114,27 @@ void draw_ui(app_state& state)
         text_disabled("Patch, then launch WeMod.");
     }
 
+    // --- Settings (collapsed by default), full window width -----------
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    if (ImGui::CollapsingHeader("Settings")) {
+        ImGui::Indent(section_indent);
+        draw_settings(state, script_ok);
+        ImGui::Unindent();
+    }
+
     // --- Log: fills the rest of the window ----------------------------
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
 
     const float line_height{ImGui::GetTextLineHeightWithSpacing()};
-    const float log_height{std::max(
-        ImGui::GetContentRegionAvail().y -
-            line_height * log_lines_reserved,
-        line_height * 4.0F)};
+    const float util_h{ImGui::GetFrameHeight() * util_height_scale};
+    const float toolbar_h{util_h + line_height + style.ItemSpacing.y * 3.0F};
+    const float log_height{std::max(ImGui::GetContentRegionAvail().y - toolbar_h,
+                                    line_height * 4.0F)};
 
     ImGui::BeginChild("##log", ImVec2(0.0F, log_height),
                       ImGuiChildFlags_Borders,
@@ -1180,39 +1155,38 @@ void draw_ui(app_state& state)
     }
     ImGui::EndChild();
 
-    // --- Bottom toolbar: Copy output / Report bug ---------------------
+    // --- Bottom toolbar: Copy / Report equal-width, version right -----
     ImGui::Spacing();
-    if (fit_button("Copy output")) {
+    const float util_w{equal_button_width(2)};
+    if (action_button("Copy output", util_w, util_h)) {
         copy_output(state);
     }
     if (ImGui::IsItemHovered()) {
         tooltip_text("Copy the log and environment info to the clipboard");
     }
     ImGui::SameLine();
-    if (fit_button("Report bug")) {
+    if (action_button("Report bug", util_w, util_h)) {
         report_bug(state);
     }
     if (ImGui::IsItemHovered()) {
         tooltip_text("Open a pre-filled GitHub issue with the log attached");
     }
+
     if (state.copied_flash > 0.0F) {
         state.copied_flash -= ImGui::GetIO().DeltaTime;
-        ImGui::SameLine();
         text_colored(color_ok, "Copied!");
+        ImGui::SameLine();
     }
-
-    // --- Floating Settings --------------------------------------------
-    if (state.settings_open) {
-        ImGui::SetNextWindowPos(
-            ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5F,
-                   viewport->WorkPos.y + viewport->WorkSize.y * 0.5F),
-            ImGuiCond_Appearing, ImVec2(0.5F, 0.5F));
-        if (ImGui::Begin("Settings", &state.settings_open,
-                         ImGuiWindowFlags_AlwaysAutoResize |
-                             ImGuiWindowFlags_NoCollapse)) {
-            draw_settings(state, script_ok);
+    {
+        const std::string version_text{std::format("v{}", gui_version)};
+        const float text_width{ImGui::CalcTextSize(version_text.c_str()).x};
+        ImGui::SameLine(ImGui::GetContentRegionAvail().x +
+                        ImGui::GetCursorPosX() - text_width);
+        ImGui::TextDisabled("%s", version_text.c_str());
+        if (ImGui::IsItemHovered()) {
+            tooltip_text(std::string(SDL_GetPlatform()) + " " +
+                         std::string(target_arch));
         }
-        ImGui::End();
     }
 
     ImGui::End();
@@ -1251,6 +1225,17 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
     ImGui::CreateContext();
     ImGui::StyleColorsDark();
 
+    // Density only: default dark colors stay. Opened padding matches
+    // the settings-page habit (generous hit targets, even gaps) so
+    // FHD and 4K both read as the same layout, just larger.
+    ImGuiStyle& style{ImGui::GetStyle()};
+    style.WindowPadding = ImVec2(16.0F, 14.0F);
+    style.FramePadding = ImVec2(14.0F, 8.0F);
+    style.ItemSpacing = ImVec2(10.0F, 8.0F);
+    style.ItemInnerSpacing = ImVec2(8.0F, 6.0F);
+    style.ScrollbarSize = 16.0F;
+    style.GrabMinSize = 14.0F;
+
     // One knob scales the whole UI: style.FontScaleDpi (ImGui 1.92+)
     // scales every font-size-derived widget, and the window was
     // created at logical size so SDL keeps the physical size constant
@@ -1258,7 +1243,7 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
     // would zero every widget, so fall back to 1.0.
     const float main_scale{SDL_GetDisplayContentScale(
         SDL_GetPrimaryDisplay())};
-    ImGui::GetStyle().FontScaleDpi = main_scale > 0.0F ? main_scale : 1.0F;
+    style.FontScaleDpi = main_scale > 0.0F ? main_scale : 1.0F;
 
     ImGui_ImplSDL3_InitForSDLRenderer(window, renderer);
     ImGui_ImplSDLRenderer3_Init(renderer);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -32,6 +32,7 @@
 //     Patch and Restore need a valid folder and the patcher script.
 //   - Status line, then Settings as a collapsing header. Patcher /
 //     Python / version.dll are path fields, tinted green or red.
+//     version.dll is prefilled with the bundled path next to the exe.
 //   - Console section: muted label, then the log filling the rest.
 //     Copy output / Clear output / Report bug share one equal-width
 //     full-span row; Copied! left and the version centered on the
@@ -235,7 +236,7 @@ struct app_state final
     std::string install_dir;
     std::string script_path;
     std::string python;
-    std::string version_dll; // empty = auto: the copy next to the exe
+    std::string version_dll; // prefilled: the copy next to the exe
     std::string log;
     std::future<run_result> pending;
     bool running{false};
@@ -250,7 +251,7 @@ struct app_state final
     std::string probed_version_dll; // ditto, for the dll probe
     fs::path resolved_install_dir;  // cached resolve_wemod_dir result
     bool script_present{false};     // the patcher script exists on disk
-    bool dll_present{false};        // effective version.dll exists on disk
+    bool dll_present{false};        // version.dll field path exists on disk
     std::chrono::steady_clock::time_point last_probe; // last stat() round
     // --- diagnostics ---
     probe_state python_ok{probe_state::unknown};
@@ -498,15 +499,6 @@ version_parts(std::string name)
     return {};
 }
 
-// The bundled patcher script: a sibling of the executable.
-[[nodiscard]] fs::path bundled_script()
-{
-    if (const char* base{SDL_GetBasePath()}) {
-        return fs::path(base) / patcher_script_name;
-    }
-    return fs::temp_directory_path() / "wemod_enhancer" / patcher_script_name;
-}
-
 // Dir the running exe sits in. SDL_GetBasePath picks it on every OS;
 // the patcher is installed next to the exe, so the whole install stays
 // one self-contained, movable folder. The result is SDL-owned internal
@@ -520,15 +512,16 @@ version_parts(std::string name)
     return fs::temp_directory_path() / "wemod_enhancer";
 }
 
-// The bundled proxy DLL, reported only when it exists on disk.
+// The bundled patcher script: a sibling of the executable.
+[[nodiscard]] fs::path bundled_script()
+{
+    return exe_dir() / patcher_script_name;
+}
+
+// Expected version.dll path next to the exe (shown in Settings).
 [[nodiscard]] fs::path bundled_version_dll()
 {
-    std::error_code ec;
-    fs::path dll{exe_dir() / version_dll_name};
-    if (fs::is_regular_file(dll, ec)) {
-        return dll;
-    }
-    return {};
+    return exe_dir() / version_dll_name;
 }
 
 // Throttled probes behind the field validity invariant: edits re-probe
@@ -551,10 +544,8 @@ void probe_filesystem(app_state& state)
     std::error_code ec;
     state.script_present = !state.script_path.empty() &&
         fs::is_regular_file(state.script_path, ec);
-    const std::string dll{!state.version_dll.empty()
-                              ? state.version_dll
-                              : bundled_version_dll().string()};
-    state.dll_present = !dll.empty() && fs::is_regular_file(dll, ec);
+    state.dll_present = !state.version_dll.empty() &&
+        fs::is_regular_file(state.version_dll, ec);
 }
 
 // SDL dialog callback: may run on another thread; it only writes a
@@ -601,15 +592,9 @@ void start_run(app_state& state, const char* subcommand)
     std::string command{shell_quote(state.python) + " -u " +
                         shell_quote(state.script_path) + " " + subcommand +
                         " --install-dir " + shell_quote(state.install_dir)};
-    if (std::string_view(subcommand) == "patch") {
-        // Field override wins; else the bundled DLL next to the exe.
-        const std::string dll{!state.version_dll.empty()
-                                  ? state.version_dll
-                                  : bundled_version_dll().string()};
-        if (!dll.empty()) {
-            shown += " --version-dll " + dll;
-            command += " --version-dll " + shell_quote(dll);
-        }
+    if (std::string_view(subcommand) == "patch" && !state.version_dll.empty()) {
+        shown += " --version-dll " + state.version_dll;
+        command += " --version-dll " + shell_quote(state.version_dll);
     }
     start_command(state, run_kind::patcher, shown, command);
 }
@@ -1014,12 +999,12 @@ void draw_settings(app_state& state)
 
     field_label("version.dll");
     help_marker(
-        "The proxy DLL the patcher drops next to WeMod. Leave empty "
-        "to use the copy bundled next to the executable.",
+        "The proxy DLL the patcher drops next to WeMod. Default: the "
+        "copy next to the executable.",
         "https://github.com/e-gleba/wemod_enhancer#wemod-enhancer");
     push_field_tint(state.dll_present);
     ImGui::SetNextItemWidth(-FLT_MIN);
-    ImGui::InputTextWithHint("##version_dll", "auto: next to the exe",
+    ImGui::InputTextWithHint("##version_dll", "version.dll next to the exe",
                              &state.version_dll);
     ImGui::PopStyleColor();
     field_fail_hover(state.dll_present, "version.dll not found");
@@ -1317,6 +1302,7 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
     state.renderer = renderer;
     state.install_dir = default_install_dir();
     state.script_path = bundled_script().string();
+    state.version_dll = bundled_version_dll().string();
     state.python = std::string(default_python);
 
     // Say what was auto-detected up front - the log doubles as the

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -25,7 +25,8 @@
 //
 // Layout (default imgui theme, untouched - hierarchy comes from
 // alignment, not colors):
-//   - One table: a stretching content column + a fixed-width action
+//   - One table with a single logical row: a stretching content
+//     column (folder field + status) and a fixed-width action
 //     column. Every button shares one width (the widest label), so
 //     Browse / Patch / Restore / Download WeMod form a single
 //     aligned stack on the right - the settings-page habit: aligned
@@ -34,6 +35,11 @@
 //   - The stack order is the workflow: pick the folder, patch,
 //     restore; Download WeMod appears only while the folder is
 //     unresolved.
+//   - Below the table, full window width: the separator, the
+//     Settings collapsing header and its inputs. TableNextColumn()
+//     selects the FIRST cell of a new row - it never spans both
+//     columns - so these sections live outside the table, like the
+//     log and the bottom toolbar.
 //   - The bottom toolbar holds the secondary utilities (Copy
 //     output, Report bug) left, the version pinned right.
 //
@@ -906,6 +912,9 @@ void help_marker(const char* text, const char* url)
     return {};
 }
 
+// The whole window: table with the folder field + the aligned action
+// stack, then full-width sections below - separator, Settings, the
+// scrolling log and the bottom toolbar. One frame = one draw call.
 void draw_ui(app_state& state)
 {
     const ImGuiViewport* viewport{ImGui::GetMainViewport()};
@@ -928,11 +937,13 @@ void draw_ui(app_state& state)
                               style.FramePadding.x * 2.0F +
                               button_padding};
 
-    // One table for the whole top block: a stretching content column
-    // plus a fixed action column - the settings-page arrangement.
-    // ImGui sizes button columns from the cell TEXT, not the widget,
-    // so the action column gets an explicit width hint; every button
-    // in it is drawn at exactly that width.
+    // One table for the folder row: a stretching content column plus a
+    // fixed action column - the settings-page arrangement. ImGui
+    // sizes button columns from the cell TEXT, not the widget, so the
+    // action column gets an explicit width hint; every button in it
+    // is drawn at exactly that width. The table ends with that row:
+    // everything below (Settings, log, toolbar) spans the full
+    // window width.
     ImGui::BeginTable("layout", 2,
                       ImGuiTableFlags_SizingStretchProp |
                           ImGuiTableFlags_NoSavedSettings);
@@ -1051,15 +1062,17 @@ void draw_ui(app_state& state)
         }
     }
 
-    // --- Settings (collapsed by default), spanning the full width ----
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn(); // spans both columns: no second cell
+    // The folder/action pair is the only row: end the table here.
+    // TableNextColumn() selects the FIRST cell of a new row - it does
+    // not span both columns - so the sections below live outside the
+    // table and cover the full window width.
+    ImGui::EndTable();
+
+    // --- Settings (collapsed by default), full window width ---------
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
 
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn(); // ditto - full-width fields for paths
     if (ImGui::CollapsingHeader("Settings")) {
         ImGui::Indent(section_indent);
 
@@ -1109,8 +1122,6 @@ void draw_ui(app_state& state)
 
         ImGui::Unindent();
     }
-
-    ImGui::EndTable();
 
     // --- Log: fills the rest of the window ----------------------------
     ImGui::Spacing();

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -24,24 +24,19 @@
 // CMake), one frame = poll the background command + draw the UI.
 //
 // Layout (default imgui theme, untouched - hierarchy comes from
-// alignment, not colors):
-//   - One table with a single logical row: a stretching content
-//     column (folder field + status) and a fixed-width action
-//     column. Every button shares one width (the widest label), so
-//     Browse / Patch / Restore / Download WeMod form a single
-//     aligned stack on the right - the settings-page habit: aligned
-//     controls read as one group, and the primary action always
-//     sits in the same spot.
-//   - The stack order is the workflow: pick the folder, patch,
-//     restore; Download WeMod appears only while the folder is
-//     unresolved.
-//   - Below the table, full window width: the separator, the
-//     Settings collapsing header and its inputs. TableNextColumn()
-//     selects the FIRST cell of a new row - it never spans both
-//     columns - so these sections live outside the table, like the
-//     log and the bottom toolbar.
-//   - The bottom toolbar holds the secondary utilities (Copy
-//     output, Report bug) left, the version pinned right.
+// alignment and scale, not colors):
+//   - Top toolbar: Settings opens a floating window (Python,
+//     patcher, version.dll); the build version is pinned right.
+//   - WeMod folder field with Browse on the same row.
+//   - Full-width action row under the path: Patch / Restore, plus
+//     Download WeMod only while the folder is unresolved. The
+//     buttons share the row equally and use a taller frame so they
+//     are easy hit targets at any DPI.
+//   - Status line, then the log filling the rest, then Copy output
+//     / Report bug on the bottom toolbar.
+//   - Window size is a fraction of the usable display (clamped) so
+//     FHD / 1440p / 4K all open comfortably; FontScaleDpi scales
+//     every font-size-derived widget.
 //
 // C++ Core Guidelines, applied where they cost nothing:
 //   - No owning raw pointers, no new/delete, no C casts; const and
@@ -179,19 +174,28 @@ constexpr std::size_t log_budget{512 * 1024};
 constexpr std::string_view default_python{
     is_windows ? std::string_view("python") : std::string_view("python3")};
 
-// Window logical size; SDL keeps the physical size constant across
-// DPIs, and style.FontScaleDpi scales every font-size-derived widget.
-constexpr std::int32_t window_width{720};
-constexpr std::int32_t window_height{480};
+// Fallback logical window size when the display cannot be queried.
+// pick_window_size() uses a fraction of the usable display so FHD /
+// 1440p / 4K all get a comfortable default; FontScaleDpi then scales
+// every font-size-derived widget. SDL keeps the physical size
+// constant across DPIs because the window is created at logical size.
+constexpr std::int32_t window_width_fallback{960};
+constexpr std::int32_t window_height_fallback{640};
+constexpr std::int32_t window_min_width{800};
+constexpr std::int32_t window_min_height{560};
+constexpr std::int32_t window_max_width{1600};
+constexpr std::int32_t window_max_height{1000};
 constexpr std::int32_t log_lines_reserved{8};
 
-// Action buttons share ONE width: the widest label plus padding.
-// Equal-width buttons in a vertical stack form a clean alignment
-// axis (the settings-page habit); per-label widths would read as a
-// ragged list and the eye would re-find the edge for every row.
-constexpr std::string_view widest_button{"Download WeMod"};
+// Extra horizontal padding on the Browse button so it matches the
+// path field's visual weight. Action buttons ignore this - they
+// stretch to share the full row.
 constexpr float button_padding{24.0F};
-constexpr float section_indent{16.0F};
+
+// Action row: taller than the default frame so Patch / Restore are
+// easy hit targets. Font-size derived via GetFrameHeight().
+constexpr float action_height_scale{1.8F};
+
 constexpr ImVec4 clear_color{0.10F, 0.10F, 0.12F, 1.00F};
 
 // Status colors (replacing the magic-number literals).
@@ -234,6 +238,7 @@ struct app_state final
     bool has_run{false};
     std::int32_t last_exit_code{0};
     float copied_flash{0.0F}; // seconds left of "Copied!" feedback
+    bool settings_open{false}; // floating Settings window
     // --- filesystem probe cache (see probe_filesystem) ---
     std::string probed_install_dir; // field text the last resolve ran on
     std::string probed_script_path; // ditto, for the script probe
@@ -328,7 +333,7 @@ void append_log(app_state& state, const std::string_view text)
 
 // Quote one argument for the shell that runs our background commands:
 // cmd.exe on Windows (double quotes, "" escapes a quote), /bin/sh
-// elsewhere (single quotes, '"' escapes a quote).
+// elsewhere (single quotes, '"''"'"' escapes a quote).
 [[nodiscard]] std::string shell_quote(const std::string_view arg)
 {
     if constexpr (is_windows) {
@@ -830,18 +835,46 @@ void report_bug(app_state& state)
     }
 }
 
-// --- layout helpers (font-size derived, DPI-correct) ------------------
-
-// Aligned action button: the shared width, default height. Every
-// caller passes the same `width`, so the stack forms one clean
-// vertical axis. Returns true when clicked.
-bool action_button(const char* label, const float width)
+// Comfortable logical window size: a fraction of the usable display,
+// clamped so laptops stay usable and 4K does not open a postage stamp.
+// HiDPI is FontScaleDpi's job - this only picks the window.
+[[nodiscard]] std::pair<std::int32_t, std::int32_t> pick_window_size()
 {
-    Expects(label != nullptr);
-    return ImGui::Button(label, ImVec2(width, 0.0F));
+    SDL_Rect usable{};
+    if (!SDL_GetDisplayUsableBounds(SDL_GetPrimaryDisplay(), &usable) ||
+        usable.w <= 0 || usable.h <= 0) {
+        return {window_width_fallback, window_height_fallback};
+    }
+    const std::int32_t width{std::clamp(usable.w / 2, window_min_width,
+                                        window_max_width)};
+    const std::int32_t height{std::clamp((usable.h * 3) / 5,
+                                         window_min_height,
+                                         window_max_height)};
+    return {width, height};
 }
 
-// Small utility button sized to its label, for the bottom toolbar
+// --- layout helpers (font-size derived, DPI-correct) ------------------
+
+// Action / Browse button at an explicit size. Height 0 keeps the
+// default frame height (path row). Returns true when clicked.
+bool action_button(const char* label, const float width, const float height)
+{
+    Expects(label != nullptr);
+    return ImGui::Button(label, ImVec2(width, height));
+}
+
+// Equal slice of the current row for `count` sibling buttons, gaps
+// included. Stretch-to-fill: the action row always spans the window.
+[[nodiscard]] float equal_button_width(const int count)
+{
+    Expects(count > 0);
+    const ImGuiStyle& style{ImGui::GetStyle()};
+    const float avail{ImGui::GetContentRegionAvail().x};
+    const float gaps{style.ItemSpacing.x * static_cast<float>(count - 1)};
+    return std::max((avail - gaps) / static_cast<float>(count), 1.0F);
+}
+
+// Small utility button sized to its label, for the toolbar rows
 // where buttons sit in one horizontal row. Returns true when clicked.
 bool fit_button(const char* label)
 {
@@ -912,9 +945,60 @@ void help_marker(const char* text, const char* url)
     return {};
 }
 
-// The whole window: table with the folder field + the aligned action
-// stack, then full-width sections below - separator, Settings, the
-// scrolling log and the bottom toolbar. One frame = one draw call.
+// Floating Settings window body: patcher / Python / version.dll.
+// Inputs stretch to the window; Dummy below sets a DPI-safe min width.
+void draw_settings(app_state& state, const bool script_ok)
+{
+    ImGui::Dummy(ImVec2(ImGui::GetFontSize() * 34.0F, 0.0F));
+
+    field_label("Patcher");
+    help_marker(
+        "wemod_enhancer.py + version.dll ship inside this package, "
+        "next to the executable - no download, no update step. If the "
+        "script is reported missing, re-download the GUI package.",
+        "https://github.com/e-gleba/wemod_enhancer/releases/latest");
+    ImGui::SameLine();
+    if (script_ok) {
+        text_colored(color_ok, "ready");
+        ImGui::SameLine();
+        text_disabled(state.script_path);
+    } else {
+        text_colored(color_err, "missing next to the exe");
+    }
+
+    ImGui::Spacing();
+
+    field_label("Python command");
+    help_marker(
+        "The interpreter that runs the patcher. Default: python on "
+        "Windows, python3 elsewhere. Point it at a full path if "
+        "Python is not on PATH.",
+        "https://www.python.org/downloads/");
+    ImGui::SameLine();
+    if (state.python_ok == probe_state::works) {
+        text_colored(color_ok, state.python_version);
+    } else if (state.python_ok == probe_state::failed) {
+        text_colored(color_err, "not working");
+    }
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::InputText("##python", &state.python);
+
+    ImGui::Spacing();
+
+    field_label("version.dll");
+    help_marker(
+        "The proxy DLL the patcher drops next to WeMod. Leave empty "
+        "to use the copy bundled next to the executable.",
+        "https://github.com/e-gleba/wemod_enhancer#wemod-enhancer");
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::InputTextWithHint("##version_dll",
+                             "auto: next to the exe",
+                             &state.version_dll);
+}
+
+// The whole window: toolbar, path+Browse, equal-width action row,
+// status, scrolling log, bottom utilities. Settings is a floating
+// window opened from the toolbar. One frame = one draw call.
 void draw_ui(app_state& state)
 {
     const ImGuiViewport* viewport{ImGui::GetMainViewport()};
@@ -930,42 +1014,39 @@ void draw_ui(app_state& state)
 
     const ImGuiStyle& style{ImGui::GetStyle()};
 
-    // Shared width of every action button: the widest label plus
-    // padding, computed from the font size so nothing clips at any
-    // DPI. One width for all actions = one alignment axis.
-    const float buttons_width{ImGui::CalcTextSize(widest_button.data()).x +
-                              style.FramePadding.x * 2.0F +
-                              button_padding};
-
-    // One table for the folder row: a stretching content column plus a
-    // fixed action column - the settings-page arrangement. ImGui
-    // sizes button columns from the cell TEXT, not the widget, so the
-    // action column gets an explicit width hint; every button in it
-    // is drawn at exactly that width. The table ends with that row:
-    // everything below (Settings, log, toolbar) spans the full
-    // window width.
-    ImGui::BeginTable("layout", 2,
-                      ImGuiTableFlags_SizingStretchProp |
-                          ImGuiTableFlags_NoSavedSettings);
-    ImGui::TableSetupColumn("content", ImGuiTableColumnFlags_WidthStretch);
-    ImGui::TableSetupColumn("actions", ImGuiTableColumnFlags_WidthFixed,
-                            buttons_width);
-
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-
-    // title bar already says "WeMod Enhancer" - no duplicate title here.
-
-    // --- WeMod folder: the only thing a user must provide -----------
-    // Validity is an invariant of the current field text, re-probed on
-    // edits and on the reprobe timer (never every frame - the resolve
-    // walks directories). Patch normalizes the field to the resolved
-    // dir so the log always shows the exact folder used.
     probe_filesystem(state);
     const fs::path& resolved_dir{state.resolved_install_dir};
     const bool install_ok{!resolved_dir.empty()};
     const bool script_ok{state.script_present};
 
+    // --- Toolbar: Settings (floating window) + version ----------------
+    if (fit_button("Settings")) {
+        state.settings_open = true;
+    }
+    if (ImGui::IsItemHovered()) {
+        tooltip_text("Python, patcher path, version.dll");
+    }
+    {
+        const std::string version_text{std::format("v{}", gui_version)};
+        const float text_width{ImGui::CalcTextSize(version_text.c_str()).x};
+        ImGui::SameLine(ImGui::GetContentRegionAvail().x +
+                        ImGui::GetCursorPosX() - text_width);
+        ImGui::TextDisabled("%s", version_text.c_str());
+        if (ImGui::IsItemHovered()) {
+            tooltip_text(std::string(SDL_GetPlatform()) + " " +
+                         std::string(target_arch));
+        }
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // --- WeMod folder + Browse on one row -----------------------------
+    // Validity is an invariant of the current field text, re-probed on
+    // edits and on the reprobe timer (never every frame - the resolve
+    // walks directories). Patch normalizes the field to the resolved
+    // dir so the log always shows the exact folder used.
     field_label("WeMod folder");
     help_marker(
         "The app-x.y.z folder with resources/app.asar inside. Pick the "
@@ -979,24 +1060,81 @@ void draw_ui(app_state& state)
                      install_ok ? "ok" : "not a WeMod install");
     }
 
-    // Valid path = quiet green tint on the field itself.
+    const float browse_w{ImGui::CalcTextSize("Browse...").x +
+                         style.FramePadding.x * 2.0F + button_padding};
+    const float path_w{std::max(ImGui::GetContentRegionAvail().x - browse_w -
+                                    style.ItemSpacing.x,
+                                ImGui::GetFontSize() * 8.0F)};
+
     if (install_ok) {
         ImGui::PushStyleColor(ImGuiCol_FrameBg, field_ok_bg);
     }
-    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::SetNextItemWidth(path_w);
     ImGui::InputTextWithHint("##install_dir", "path to WeMod",
                              &state.install_dir);
     if (install_ok) {
         ImGui::PopStyleColor();
     }
+    ImGui::SameLine();
+    if (action_button("Browse...", browse_w, 0.0F)) {
+        SDL_ShowOpenFolderDialog(on_folder_chosen, &state, state.window,
+                                 state.install_dir.empty()
+                                     ? nullptr
+                                     : state.install_dir.c_str(),
+                                 false);
+    }
 
-    // The resolved app-x.y.z dir when it differs from the field text.
     if (install_ok && resolved_dir.string() != state.install_dir) {
         text_disabled(resolved_dir.string());
     }
 
+    // --- Actions: equal-width row, full span under the path -----------
+    // Count = 2 (Patch, Restore) or 3 (+ Download WeMod while the
+    // folder is unresolved). Every button gets the same slice so the
+    // row is one alignment axis, whatever the labels.
+    ImGui::Spacing();
+    const int action_count{install_ok ? 2 : 3};
+    const float action_w{equal_button_width(action_count)};
+    const float action_h{ImGui::GetFrameHeight() * action_height_scale};
+
+    const char* block_reason{patch_block_reason(install_ok, script_ok)};
+    const bool blocked{state.running || block_reason != nullptr};
+    ImGui::BeginDisabled(blocked);
+    if (action_button("Patch", action_w, action_h)) {
+        // Normalize the field to the resolved dir: the log then shows
+        // the exact folder the patcher ran against.
+        state.install_dir = resolved_dir.string();
+        start_run(state, "patch");
+    }
+    ImGui::EndDisabled();
+    if (block_reason != nullptr &&
+        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        tooltip_text(block_reason);
+    }
+
+    ImGui::SameLine();
+    ImGui::BeginDisabled(state.running);
+    if (action_button("Restore", action_w, action_h)) {
+        start_run(state, "restore");
+    }
+    ImGui::EndDisabled();
+
+    if (!install_ok) {
+        ImGui::SameLine();
+        if (action_button("Download WeMod", action_w, action_h)) {
+            start_wemod_download(state);
+        }
+        if (ImGui::IsItemHovered()) {
+            tooltip_text(is_windows
+                             ? "Download the official WeMod installer into "
+                               "your Downloads folder and run it"
+                             : "Clone wemod-launcher into ~/wemod-launcher "
+                               "and open the setup tutorial");
+        }
+    }
+
     // --- Status -------------------------------------------------------
-    // One line under the folder: what is running, how the last run
+    // One line under the actions: what is running, how the last run
     // ended, or the initial hint. Detail lives in the log below.
     ImGui::Spacing();
     if (state.running) {
@@ -1010,117 +1148,6 @@ void draw_ui(app_state& state)
         }
     } else {
         text_disabled("Patch, then launch WeMod.");
-    }
-
-    // --- Actions: one aligned stack, right column --------------------
-    // Every button shares the width computed above, so the stack
-    // forms a single vertical alignment axis - the primary action
-    // always sits in the same spot, whatever the labels or the state.
-    // Stack order = workflow order: pick the folder, patch, restore;
-    // Download WeMod appears only while the folder is unresolved.
-    ImGui::TableNextColumn();
-
-    if (action_button("Browse...", buttons_width)) {
-        SDL_ShowOpenFolderDialog(on_folder_chosen, &state, state.window,
-                                 state.install_dir.empty()
-                                     ? nullptr
-                                     : state.install_dir.c_str(),
-                                 false);
-    }
-
-    const char* block_reason{patch_block_reason(install_ok, script_ok)};
-    const bool blocked{state.running || block_reason != nullptr};
-    ImGui::BeginDisabled(blocked);
-    if (action_button("Patch", buttons_width)) {
-        // Normalize the field to the resolved dir: the log then shows
-        // the exact folder the patcher ran against.
-        state.install_dir = resolved_dir.string();
-        start_run(state, "patch");
-    }
-    ImGui::EndDisabled();
-    if (block_reason != nullptr &&
-        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-        tooltip_text(block_reason);
-    }
-
-    ImGui::BeginDisabled(state.running);
-    if (action_button("Restore", buttons_width)) {
-        start_run(state, "restore");
-    }
-    ImGui::EndDisabled();
-
-    if (!install_ok) {
-        if (action_button("Download WeMod", buttons_width)) {
-            start_wemod_download(state);
-        }
-        if (ImGui::IsItemHovered()) {
-            tooltip_text(is_windows
-                             ? "Download the official WeMod installer into "
-                               "your Downloads folder and run it"
-                             : "Clone wemod-launcher into ~/wemod-launcher "
-                               "and open the setup tutorial");
-        }
-    }
-
-    // The folder/action pair is the only row: end the table here.
-    // TableNextColumn() selects the FIRST cell of a new row - it does
-    // not span both columns - so the sections below live outside the
-    // table and cover the full window width.
-    ImGui::EndTable();
-
-    // --- Settings (collapsed by default), full window width ---------
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
-    if (ImGui::CollapsingHeader("Settings")) {
-        ImGui::Indent(section_indent);
-
-        field_label("Patcher");
-        help_marker(
-            "wemod_enhancer.py + version.dll ship inside this package, "
-            "next to the executable - no download, no update step. If the "
-            "script is reported missing, re-download the GUI package.",
-            "https://github.com/e-gleba/wemod_enhancer/releases/latest");
-        ImGui::SameLine();
-        if (script_ok) {
-            text_colored(color_ok, "ready");
-            ImGui::SameLine();
-            text_disabled(state.script_path);
-        } else {
-            text_colored(color_err, "missing next to the exe");
-        }
-
-        ImGui::Spacing();
-
-        field_label("Python command");
-        help_marker(
-            "The interpreter that runs the patcher. Default: python on "
-            "Windows, python3 elsewhere. Point it at a full path if "
-            "Python is not on PATH.",
-            "https://www.python.org/downloads/");
-        ImGui::SameLine();
-        if (state.python_ok == probe_state::works) {
-            text_colored(color_ok, state.python_version);
-        } else if (state.python_ok == probe_state::failed) {
-            text_colored(color_err, "not working");
-        }
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        ImGui::InputText("##python", &state.python);
-
-        ImGui::Spacing();
-
-        field_label("version.dll");
-        help_marker(
-            "The proxy DLL the patcher drops next to WeMod. Leave empty "
-            "to use the copy bundled next to the executable.",
-            "https://github.com/e-gleba/wemod_enhancer#wemod-enhancer");
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        ImGui::InputTextWithHint("##version_dll",
-                                 "auto: next to the exe",
-                                 &state.version_dll);
-
-        ImGui::Unindent();
     }
 
     // --- Log: fills the rest of the window ----------------------------
@@ -1153,7 +1180,7 @@ void draw_ui(app_state& state)
     }
     ImGui::EndChild();
 
-    // --- Bottom toolbar: secondary utilities left, version right ------
+    // --- Bottom toolbar: Copy output / Report bug ---------------------
     ImGui::Spacing();
     if (fit_button("Copy output")) {
         copy_output(state);
@@ -1174,19 +1201,18 @@ void draw_ui(app_state& state)
         text_colored(color_ok, "Copied!");
     }
 
-    // Build version pinned to the right end of the bottom toolbar row:
-    // the CMake project version, injected at compile time - the GUI
-    // can never show a version that differs from its package.
-    {
-        const std::string version_text{std::format("v{}", gui_version)};
-        const float text_width{ImGui::CalcTextSize(version_text.c_str()).x};
-        ImGui::SameLine(ImGui::GetContentRegionAvail().x +
-                        ImGui::GetCursorPosX() - text_width);
-        ImGui::TextDisabled("%s", version_text.c_str());
-        if (ImGui::IsItemHovered()) {
-            tooltip_text(std::string(SDL_GetPlatform()) + " " +
-                         std::string(target_arch));
+    // --- Floating Settings --------------------------------------------
+    if (state.settings_open) {
+        ImGui::SetNextWindowPos(
+            ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5F,
+                   viewport->WorkPos.y + viewport->WorkSize.y * 0.5F),
+            ImGuiCond_Appearing, ImVec2(0.5F, 0.5F));
+        if (ImGui::Begin("Settings", &state.settings_open,
+                         ImGuiWindowFlags_AlwaysAutoResize |
+                             ImGuiWindowFlags_NoCollapse)) {
+            draw_settings(state, script_ok);
         }
+        ImGui::End();
     }
 
     ImGui::End();
@@ -1207,16 +1233,19 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
         return SDL_APP_FAILURE;
     }
 
+    const auto [win_w, win_h]{pick_window_size()};
+
     SDL_Window* window{nullptr};
     SDL_Renderer* renderer{nullptr};
     if (!SDL_CreateWindowAndRenderer(
-            "WeMod Enhancer", window_width, window_height,
+            "WeMod Enhancer", win_w, win_h,
             SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY, &window,
             &renderer)) {
         sdl_log_error(std::string("SDL_CreateWindowAndRenderer: ") +
                       SDL_GetError());
         return SDL_APP_FAILURE;
     }
+    SDL_SetWindowMinimumSize(window, window_min_width, window_min_height);
 
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -25,13 +25,13 @@
 //
 // Layout (default imgui theme, untouched colors - hierarchy comes
 // from alignment, padding and scale):
-//   - WeMod folder field with Browse on the same row.
+//   - WeMod folder field with Browse on the same row. Validity is
+//     the field color (green / red), no extra status word.
 //   - Full-width action row under the path: Patch / Restore, plus
-//     Download WeMod only while the folder is unresolved. Buttons
-//     share the row equally. Same height as Copy / Clear / Report
-//     so every full-span row reads as one control language.
-//   - Status line, then Settings as a collapsing header (collapsed
-//     by default, full width - Python / patcher / version.dll).
+//     Download WeMod only while the folder is unresolved. Both
+//     Patch and Restore need a valid folder and the patcher script.
+//   - Status line, then Settings as a collapsing header. Patcher /
+//     Python / version.dll are path fields, tinted green or red.
 //   - Console section: muted label, then the log filling the rest.
 //     Copy output / Clear output / Report bug share one equal-width
 //     full-span row; Copied! left and the version centered on the
@@ -206,8 +206,10 @@ constexpr ImVec4 clear_color{0.10F, 0.10F, 0.12F, 1.00F};
 constexpr ImVec4 color_ok{0.35F, 0.85F, 0.45F, 1.00F};
 constexpr ImVec4 color_err{0.90F, 0.30F, 0.30F, 1.00F};
 
-// Input field tint when the path is valid: quiet green fill.
+// Quiet fill tints for path fields. Validity is the color, not a
+// word next to the label.
 constexpr ImVec4 field_ok_bg{0.14F, 0.32F, 0.16F, 0.70F};
+constexpr ImVec4 field_err_bg{0.32F, 0.14F, 0.14F, 0.70F};
 
 struct run_result final
 {
@@ -245,8 +247,10 @@ struct app_state final
     // --- filesystem probe cache (see probe_filesystem) ---
     std::string probed_install_dir; // field text the last resolve ran on
     std::string probed_script_path; // ditto, for the script probe
+    std::string probed_version_dll; // ditto, for the dll probe
     fs::path resolved_install_dir;  // cached resolve_wemod_dir result
-    bool script_present{false};     // the bundled script exists on disk
+    bool script_present{false};     // the patcher script exists on disk
+    bool dll_present{false};        // effective version.dll exists on disk
     std::chrono::steady_clock::time_point last_probe; // last stat() round
     // --- diagnostics ---
     probe_state python_ok{probe_state::unknown};
@@ -494,37 +498,13 @@ version_parts(std::string name)
     return {};
 }
 
-// Throttled probes behind the field validity invariant: edits re-probe
-// immediately, reprobe_interval catches on-disk changes.
-void probe_filesystem(app_state& state)
+// The bundled patcher script: a sibling of the executable.
+[[nodiscard]] fs::path bundled_script()
 {
-    const auto now{std::chrono::steady_clock::now()};
-    if (state.probed_install_dir == state.install_dir &&
-        state.probed_script_path == state.script_path &&
-        (now - state.last_probe) < reprobe_interval) {
-        return;
+    if (const char* base{SDL_GetBasePath()}) {
+        return fs::path(base) / patcher_script_name;
     }
-    state.probed_install_dir = state.install_dir;
-    state.probed_script_path = state.script_path;
-    state.last_probe = now;
-    state.resolved_install_dir = resolve_wemod_dir(state.install_dir);
-    // error_code overload: a malformed path in the field must not throw.
-    std::error_code ec;
-    state.script_present = !state.script_path.empty() &&
-        fs::is_regular_file(state.script_path, ec);
-}
-
-// SDL dialog callback: may run on another thread; it only writes a
-// std::string that the UI thread reads next frame - safe in practice
-// because the dialog is modal and the field is not edited meanwhile.
-void SDLCALL on_folder_chosen(void* userdata,
-                              const char* const* filelist,
-                              int /*filter*/)
-{
-    auto& state{state_of(userdata)};
-    if (filelist != nullptr && filelist[0] != nullptr) {
-        state.install_dir = filelist[0];
-    }
+    return fs::temp_directory_path() / "wemod_enhancer" / patcher_script_name;
 }
 
 // Dir the running exe sits in. SDL_GetBasePath picks it on every OS;
@@ -540,12 +520,6 @@ void SDLCALL on_folder_chosen(void* userdata,
     return fs::temp_directory_path() / "wemod_enhancer";
 }
 
-// The bundled patcher script: a sibling of the executable.
-[[nodiscard]] fs::path bundled_script()
-{
-    return exe_dir() / patcher_script_name;
-}
-
 // The bundled proxy DLL, reported only when it exists on disk.
 [[nodiscard]] fs::path bundled_version_dll()
 {
@@ -555,6 +529,45 @@ void SDLCALL on_folder_chosen(void* userdata,
         return dll;
     }
     return {};
+}
+
+// Throttled probes behind the field validity invariant: edits re-probe
+// immediately, reprobe_interval catches on-disk changes.
+void probe_filesystem(app_state& state)
+{
+    const auto now{std::chrono::steady_clock::now()};
+    if (state.probed_install_dir == state.install_dir &&
+        state.probed_script_path == state.script_path &&
+        state.probed_version_dll == state.version_dll &&
+        (now - state.last_probe) < reprobe_interval) {
+        return;
+    }
+    state.probed_install_dir = state.install_dir;
+    state.probed_script_path = state.script_path;
+    state.probed_version_dll = state.version_dll;
+    state.last_probe = now;
+    state.resolved_install_dir = resolve_wemod_dir(state.install_dir);
+    // error_code overload: a malformed path in the field must not throw.
+    std::error_code ec;
+    state.script_present = !state.script_path.empty() &&
+        fs::is_regular_file(state.script_path, ec);
+    const std::string dll{!state.version_dll.empty()
+                              ? state.version_dll
+                              : bundled_version_dll().string()};
+    state.dll_present = !dll.empty() && fs::is_regular_file(dll, ec);
+}
+
+// SDL dialog callback: may run on another thread; it only writes a
+// std::string that the UI thread reads next frame - safe in practice
+// because the dialog is modal and the field is not edited meanwhile.
+void SDLCALL on_folder_chosen(void* userdata,
+                              const char* const* filelist,
+                              int /*filter*/)
+{
+    auto& state{state_of(userdata)};
+    if (filelist != nullptr && filelist[0] != nullptr) {
+        state.install_dir = filelist[0];
+    }
 }
 
 // Launch a background command and stream its output into the log.
@@ -912,18 +925,33 @@ void help_marker(const char* text, const char* url)
     }
 }
 
-// Why Patch is disabled, or nullptr when it can run.
-[[nodiscard]] const char* patch_block_reason(const bool install_ok,
-                                             const bool script_ok)
+// Quiet green / red fill on the next input. Validity is the color.
+void push_field_tint(const bool ok)
+{
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, ok ? field_ok_bg : field_err_bg);
+}
+
+// Hover on a red field: one line, no extra label clutter.
+void field_fail_hover(const bool ok, const char* why)
+{
+    Expects(why != nullptr);
+    if (!ok && ImGui::IsItemHovered()) {
+        tooltip_text(why);
+    }
+}
+
+// Why Patch / Restore is disabled, or nullptr when it can run.
+[[nodiscard]] const char* run_block_reason(const bool install_ok,
+                                           const bool script_ok)
 {
     if (!install_ok && !script_ok) {
-        return "Needs a valid WeMod folder and the patcher";
+        return "Needs a WeMod folder and the patcher script";
     }
     if (!install_ok) {
-        return "Pick a valid WeMod folder first";
+        return "Select a WeMod folder first";
     }
     if (!script_ok) {
-        return "The bundled patcher is missing - see Settings";
+        return "Patcher script missing - open Settings";
     }
     return nullptr;
 }
@@ -943,23 +971,20 @@ void help_marker(const char* text, const char* url)
     return {};
 }
 
-// Settings body: patcher / Python / version.dll. Inputs stretch.
-void draw_settings(app_state& state, const bool script_ok)
+// Settings body: patcher / Python / version.dll as tinted path fields.
+void draw_settings(app_state& state)
 {
     field_label("Patcher");
     help_marker(
-        "wemod_enhancer.py + version.dll ship inside this package, "
-        "next to the executable - no download, no update step. If the "
-        "script is reported missing, re-download the GUI package.",
+        "wemod_enhancer.py ships next to the executable. Re-download "
+        "the GUI package if the field stays red.",
         "https://github.com/e-gleba/wemod_enhancer/releases/latest");
-    ImGui::SameLine();
-    if (script_ok) {
-        text_colored(color_ok, "ready");
-        ImGui::SameLine();
-        text_disabled(state.script_path);
-    } else {
-        text_colored(color_err, "missing next to the exe");
-    }
+    push_field_tint(state.script_present);
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::InputTextWithHint("##script_path", "wemod_enhancer.py next to the exe",
+                             &state.script_path);
+    ImGui::PopStyleColor();
+    field_fail_hover(state.script_present, "Patcher script not found");
 
     ImGui::Spacing();
 
@@ -971,12 +996,19 @@ void draw_settings(app_state& state, const bool script_ok)
         "https://www.python.org/downloads/");
     ImGui::SameLine();
     if (state.python_ok == probe_state::works) {
-        text_colored(color_ok, state.python_version);
-    } else if (state.python_ok == probe_state::failed) {
-        text_colored(color_err, "not working");
+        text_disabled(state.python_version);
+    }
+    const bool python_tinted{state.python_ok != probe_state::unknown};
+    const bool python_ok{state.python_ok == probe_state::works};
+    if (python_tinted) {
+        push_field_tint(python_ok);
     }
     ImGui::SetNextItemWidth(-FLT_MIN);
-    ImGui::InputText("##python", &state.python);
+    ImGui::InputTextWithHint("##python", "python / python3", &state.python);
+    if (python_tinted) {
+        ImGui::PopStyleColor();
+        field_fail_hover(python_ok, "Python failed to start");
+    }
 
     ImGui::Spacing();
 
@@ -985,10 +1017,12 @@ void draw_settings(app_state& state, const bool script_ok)
         "The proxy DLL the patcher drops next to WeMod. Leave empty "
         "to use the copy bundled next to the executable.",
         "https://github.com/e-gleba/wemod_enhancer#wemod-enhancer");
+    push_field_tint(state.dll_present);
     ImGui::SetNextItemWidth(-FLT_MIN);
-    ImGui::InputTextWithHint("##version_dll",
-                             "auto: next to the exe",
+    ImGui::InputTextWithHint("##version_dll", "auto: next to the exe",
                              &state.version_dll);
+    ImGui::PopStyleColor();
+    field_fail_hover(state.dll_present, "version.dll not found");
 }
 
 // The whole window: path+Browse, equal-width action row, status,
@@ -1016,10 +1050,9 @@ void draw_ui(app_state& state)
     const bool script_ok{state.script_present};
 
     // --- WeMod folder + Browse on one row -----------------------------
-    // Validity is an invariant of the current field text, re-probed on
-    // edits and on the reprobe timer (never every frame - the resolve
-    // walks directories). Patch normalizes the field to the resolved
-    // dir so the log always shows the exact folder used.
+    // Validity is the field color (green / red), re-probed on edits
+    // and on the reprobe timer. Empty stays default. Patch normalizes
+    // the field to the resolved dir so the log shows the exact folder.
     field_label("WeMod folder");
     help_marker(
         "The app-x.y.z folder with resources/app.asar inside. Pick the "
@@ -1027,11 +1060,6 @@ void draw_ui(app_state& state)
         "Linux: the wemod-launcher clone works too - after the first "
         "run + login its wemod_data/wemod_bin is picked up.",
         "https://github.com/e-gleba/wemod_enhancer#quick-start");
-    ImGui::SameLine();
-    if (!state.install_dir.empty()) {
-        text_colored(install_ok ? color_ok : color_err,
-                     install_ok ? "ok" : "not a WeMod install");
-    }
 
     const float browse_w{ImGui::CalcTextSize("Browse...").x +
                          (style.FramePadding.x * 2.0F) + button_padding};
@@ -1039,14 +1067,16 @@ void draw_ui(app_state& state)
                                     style.ItemSpacing.x,
                                 ImGui::GetFontSize() * 8.0F)};
 
-    if (install_ok) {
-        ImGui::PushStyleColor(ImGuiCol_FrameBg, field_ok_bg);
+    const bool folder_tinted{!state.install_dir.empty()};
+    if (folder_tinted) {
+        push_field_tint(install_ok);
     }
     ImGui::SetNextItemWidth(path_w);
     ImGui::InputTextWithHint("##install_dir", "path to WeMod",
                              &state.install_dir);
-    if (install_ok) {
+    if (folder_tinted) {
         ImGui::PopStyleColor();
+        field_fail_hover(install_ok, "Not a WeMod install");
     }
     ImGui::SameLine();
     if (action_button("Browse...", browse_w, 0.0F)) {
@@ -1063,14 +1093,13 @@ void draw_ui(app_state& state)
 
     // --- Actions: equal-width row, full span under the path -----------
     // Count = 2 (Patch, Restore) or 3 (+ Download WeMod while the
-    // folder is unresolved). Every button gets the same slice so the
-    // row is one alignment axis, whatever the labels. Height matches
-    // the Copy / Clear / Report row below.
+    // folder is unresolved). Patch and Restore share one block
+    // reason: valid folder + patcher script.
     ImGui::Spacing();
     const int action_count{install_ok ? 2 : 3};
     const float action_w{equal_button_width(action_count)};
 
-    const char* block_reason{patch_block_reason(install_ok, script_ok)};
+    const char* block_reason{run_block_reason(install_ok, script_ok)};
     const bool blocked{state.running || block_reason != nullptr};
     ImGui::BeginDisabled(blocked);
     if (action_button("Patch", action_w, row_h)) {
@@ -1086,11 +1115,15 @@ void draw_ui(app_state& state)
     }
 
     ImGui::SameLine();
-    ImGui::BeginDisabled(state.running);
+    ImGui::BeginDisabled(blocked);
     if (action_button("Restore", action_w, row_h)) {
         start_run(state, "restore");
     }
     ImGui::EndDisabled();
+    if (block_reason != nullptr &&
+        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        tooltip_text(block_reason);
+    }
 
     if (!install_ok) {
         ImGui::SameLine();
@@ -1116,8 +1149,9 @@ void draw_ui(app_state& state)
         if (state.last_exit_code == 0) {
             text_colored(color_ok, "Done. Launch WeMod - Pro is active.");
         } else {
-            text_colored(color_err, std::format("Failed (exit code {})",
-                                                state.last_exit_code));
+            text_colored(color_err,
+                         std::format("Failed (exit code {})",
+                                     state.last_exit_code));
         }
     } else {
         text_disabled("Patch, then launch WeMod.");
@@ -1130,7 +1164,7 @@ void draw_ui(app_state& state)
 
     if (ImGui::CollapsingHeader("Settings")) {
         ImGui::Indent(section_indent);
-        draw_settings(state, script_ok);
+        draw_settings(state);
         ImGui::Unindent();
     }
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -23,6 +23,20 @@
 // Structure: SDL3 app callbacks (SDL_MAIN_USE_CALLBACKS is set via
 // CMake), one frame = poll the background command + draw the UI.
 //
+// Layout (default imgui theme, untouched - hierarchy comes from
+// alignment, not colors):
+//   - One table: a stretching content column + a fixed-width action
+//     column. Every button shares one width (the widest label), so
+//     Browse / Patch / Restore / Download WeMod form a single
+//     aligned stack on the right - the settings-page habit: aligned
+//     controls read as one group, and the primary action always
+//     sits in the same spot.
+//   - The stack order is the workflow: pick the folder, patch,
+//     restore; Download WeMod appears only while the folder is
+//     unresolved.
+//   - The bottom toolbar holds the secondary utilities (Copy
+//     output, Report bug) left, the version pinned right.
+//
 // C++ Core Guidelines, applied where they cost nothing:
 //   - No owning raw pointers, no new/delete, no C casts; const and
 //     #ifdef wherever both branches compile; the preprocessor only
@@ -165,15 +179,13 @@ constexpr std::int32_t window_width{720};
 constexpr std::int32_t window_height{480};
 constexpr std::int32_t log_lines_reserved{8};
 
-// ImGui tables size columns from the cell TEXT, not the widget: a
-// button column sized for "Patch" clips "Restore". Padding for the
-// widest label keeps the column wide enough for every state.
+// Action buttons share ONE width: the widest label plus padding.
+// Equal-width buttons in a vertical stack form a clean alignment
+// axis (the settings-page habit); per-label widths would read as a
+// ragged list and the eye would re-find the edge for every row.
 constexpr std::string_view widest_button{"Download WeMod"};
 constexpr float button_padding{24.0F};
-constexpr float field_padding{12.0F};
 constexpr float section_indent{16.0F};
-constexpr float field_width_ratio{0.55F};
-constexpr float min_field_width{220.0F};
 constexpr ImVec4 clear_color{0.10F, 0.10F, 0.12F, 1.00F};
 
 // Status colors (replacing the magic-number literals).
@@ -814,7 +826,17 @@ void report_bug(app_state& state)
 
 // --- layout helpers (font-size derived, DPI-correct) ------------------
 
-// Button sized to its label; returns true when clicked.
+// Aligned action button: the shared width, default height. Every
+// caller passes the same `width`, so the stack forms one clean
+// vertical axis. Returns true when clicked.
+bool action_button(const char* label, const float width)
+{
+    Expects(label != nullptr);
+    return ImGui::Button(label, ImVec2(width, 0.0F));
+}
+
+// Small utility button sized to its label, for the bottom toolbar
+// where buttons sit in one horizontal row. Returns true when clicked.
 bool fit_button(const char* label)
 {
     Expects(label != nullptr);
@@ -897,20 +919,25 @@ void draw_ui(app_state& state)
 
     ImGui::Begin("##main", nullptr, window_flags);
 
-    // One table for the whole window: labels column + buttons column.
-    // ImGui sizes button columns from the cell TEXT, so the buttons
-    // column gets an explicit width hint for the widest label -
-    // otherwise "Restore" clips where "Patch" fit.
     const ImGuiStyle& style{ImGui::GetStyle()};
+
+    // Shared width of every action button: the widest label plus
+    // padding, computed from the font size so nothing clips at any
+    // DPI. One width for all actions = one alignment axis.
     const float buttons_width{ImGui::CalcTextSize(widest_button.data()).x +
                               style.FramePadding.x * 2.0F +
                               button_padding};
 
+    // One table for the whole top block: a stretching content column
+    // plus a fixed action column - the settings-page arrangement.
+    // ImGui sizes button columns from the cell TEXT, not the widget,
+    // so the action column gets an explicit width hint; every button
+    // in it is drawn at exactly that width.
     ImGui::BeginTable("layout", 2,
                       ImGuiTableFlags_SizingStretchProp |
                           ImGuiTableFlags_NoSavedSettings);
-    ImGui::TableSetupColumn("fields", ImGuiTableColumnFlags_WidthStretch);
-    ImGui::TableSetupColumn("buttons", ImGuiTableColumnFlags_WidthFixed,
+    ImGui::TableSetupColumn("content", ImGuiTableColumnFlags_WidthStretch);
+    ImGui::TableSetupColumn("actions", ImGuiTableColumnFlags_WidthFixed,
                             buttons_width);
 
     ImGui::TableNextRow();
@@ -957,38 +984,10 @@ void draw_ui(app_state& state)
         text_disabled(resolved_dir.string());
     }
 
-    ImGui::TableNextColumn();
-    if (fit_button("Browse...")) {
-        SDL_ShowOpenFolderDialog(on_folder_chosen, &state, state.window,
-                                 state.install_dir.empty()
-                                     ? nullptr
-                                     : state.install_dir.c_str(),
-                                 false);
-    }
-    if (!install_ok) {
-        if (fit_button("Download WeMod")) {
-            start_wemod_download(state);
-        }
-        if (ImGui::IsItemHovered()) {
-            tooltip_text(is_windows
-                             ? "Download the official WeMod installer into "
-                               "your Downloads folder and run it"
-                             : "Clone wemod-launcher into ~/wemod-launcher "
-                               "and open the setup tutorial");
-        }
-    }
-
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
+    // --- Status -------------------------------------------------------
+    // One line under the folder: what is running, how the last run
+    // ended, or the initial hint. Detail lives in the log below.
     ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-    ImGui::TableNextColumn();
-
-    // --- Actions ------------------------------------------------------
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-
     if (state.running) {
         text_disabled(running_status(state.kind));
     } else if (state.has_run) {
@@ -1002,11 +1001,26 @@ void draw_ui(app_state& state)
         text_disabled("Patch, then launch WeMod.");
     }
 
+    // --- Actions: one aligned stack, right column --------------------
+    // Every button shares the width computed above, so the stack
+    // forms a single vertical alignment axis - the primary action
+    // always sits in the same spot, whatever the labels or the state.
+    // Stack order = workflow order: pick the folder, patch, restore;
+    // Download WeMod appears only while the folder is unresolved.
     ImGui::TableNextColumn();
+
+    if (action_button("Browse...", buttons_width)) {
+        SDL_ShowOpenFolderDialog(on_folder_chosen, &state, state.window,
+                                 state.install_dir.empty()
+                                     ? nullptr
+                                     : state.install_dir.c_str(),
+                                 false);
+    }
+
     const char* block_reason{patch_block_reason(install_ok, script_ok)};
     const bool blocked{state.running || block_reason != nullptr};
     ImGui::BeginDisabled(blocked);
-    if (fit_button("Patch")) {
+    if (action_button("Patch", buttons_width)) {
         // Normalize the field to the resolved dir: the log then shows
         // the exact folder the patcher ran against.
         state.install_dir = resolved_dir.string();
@@ -1017,22 +1031,35 @@ void draw_ui(app_state& state)
         ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
         tooltip_text(block_reason);
     }
+
     ImGui::BeginDisabled(state.running);
-    if (fit_button("Restore")) {
+    if (action_button("Restore", buttons_width)) {
         start_run(state, "restore");
     }
     ImGui::EndDisabled();
 
-    // --- Settings (collapsed by default) ------------------------------
+    if (!install_ok) {
+        if (action_button("Download WeMod", buttons_width)) {
+            start_wemod_download(state);
+        }
+        if (ImGui::IsItemHovered()) {
+            tooltip_text(is_windows
+                             ? "Download the official WeMod installer into "
+                               "your Downloads folder and run it"
+                             : "Clone wemod-launcher into ~/wemod-launcher "
+                               "and open the setup tutorial");
+        }
+    }
+
+    // --- Settings (collapsed by default), spanning the full width ----
     ImGui::TableNextRow();
-    ImGui::TableNextColumn();
+    ImGui::TableNextColumn(); // spans both columns: no second cell
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
-    ImGui::TableNextColumn();
 
     ImGui::TableNextRow();
-    ImGui::TableNextColumn();
+    ImGui::TableNextColumn(); // ditto - full-width fields for paths
     if (ImGui::CollapsingHeader("Settings")) {
         ImGui::Indent(section_indent);
 
@@ -1115,7 +1142,7 @@ void draw_ui(app_state& state)
     }
     ImGui::EndChild();
 
-    // --- Bottom toolbar -------------------------------------------------
+    // --- Bottom toolbar: secondary utilities left, version right ------
     ImGui::Spacing();
     if (fit_button("Copy output")) {
         copy_output(state);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -32,9 +32,9 @@
 //     hit targets at any DPI.
 //   - Status line, then Settings as a collapsing header (collapsed
 //     by default, full width - Python / patcher / version.dll).
-//   - Log fills the rest. Copy output / Report bug share one
-//     equal-width full-span row; Copied! left and version right on
-//     the footer line under it.
+//   - Log fills the rest. Copy output / Clear output / Report bug
+//     share one equal-width full-span row; Copied! left and the
+//     version centered on the footer line under it.
 //   - Window size is a fraction of the usable display (clamped) so
 //     FHD / 1440p / 4K all open comfortably; FontScaleDpi scales
 //     every font-size-derived widget.
@@ -170,7 +170,8 @@ constexpr std::size_t issue_log_budget{3000};
 constexpr auto reprobe_interval{std::chrono::milliseconds(500)};
 
 // Past this budget the oldest log lines are dropped at a newline.
-constexpr std::size_t log_budget{512 * 1024};
+// UZ: multiply in std::size_t, no int-to-size_t widening of the product.
+constexpr std::size_t log_budget{512UZ * 1024UZ};
 
 constexpr std::string_view default_python{
     is_windows ? std::string_view("python") : std::string_view("python3")};
@@ -194,8 +195,8 @@ constexpr float button_padding{24.0F};
 constexpr float section_indent{16.0F};
 
 // Action row (Patch / Restore / Download): taller than the default
-// frame so they are easy hit targets. Utility row (Copy / Report)
-// is a step down - still large, not competing with Patch.
+// frame so they are easy hit targets. Utility row (Copy / Clear /
+// Report) is a step down - still large, not competing with Patch.
 // Font-size derived via GetFrameHeight().
 constexpr float action_height_scale{2.0F};
 constexpr float util_height_scale{1.55F};
@@ -535,7 +536,7 @@ void SDLCALL on_folder_chosen(void* userdata,
 [[nodiscard]] fs::path exe_dir()
 {
     if (const char* base{SDL_GetBasePath()}) {
-        return fs::path(base);
+        return {base};
     }
     return fs::temp_directory_path() / "wemod_enhancer";
 }
@@ -817,6 +818,13 @@ void copy_output(app_state& state)
     state.copied_flash = 1.5F;
 }
 
+// Drop the log. The next patch run fills it again.
+void clear_output(app_state& state)
+{
+    state.log.clear();
+    state.copied_flash = 0.0F;
+}
+
 // Open a pre-filled bug report: the log tail and the environment ride
 // in the body. SDL_OpenURL handles the platform browser.
 void report_bug(app_state& state)
@@ -894,7 +902,7 @@ void help_marker(const char* text, const char* url)
     Expects(text != nullptr);
     Expects(url != nullptr);
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    text_disabled("(?)");
     if (ImGui::IsItemHovered()) {
         tooltip_text(text);
     }
@@ -985,7 +993,7 @@ void draw_settings(app_state& state, const bool script_ok)
 }
 
 // The whole window: path+Browse, equal-width action row, status,
-// collapsing Settings, scrolling log, equal-width Copy/Report.
+// collapsing Settings, scrolling log, equal-width Copy/Clear/Report.
 // One frame = one draw call.
 void draw_ui(app_state& state)
 {
@@ -1026,7 +1034,7 @@ void draw_ui(app_state& state)
     }
 
     const float browse_w{ImGui::CalcTextSize("Browse...").x +
-                         style.FramePadding.x * 2.0F + button_padding};
+                         (style.FramePadding.x * 2.0F) + button_padding};
     const float path_w{std::max(ImGui::GetContentRegionAvail().x - browse_w -
                                     style.ItemSpacing.x,
                                 ImGui::GetFontSize() * 8.0F)};
@@ -1133,7 +1141,7 @@ void draw_ui(app_state& state)
 
     const float line_height{ImGui::GetTextLineHeightWithSpacing()};
     const float util_h{ImGui::GetFrameHeight() * util_height_scale};
-    const float toolbar_h{util_h + line_height + style.ItemSpacing.y * 3.0F};
+    const float toolbar_h{util_h + line_height + (style.ItemSpacing.y * 3.0F)};
     const float log_height{std::max(ImGui::GetContentRegionAvail().y - toolbar_h,
                                     line_height * 4.0F)};
 
@@ -1156,14 +1164,23 @@ void draw_ui(app_state& state)
     }
     ImGui::EndChild();
 
-    // --- Bottom toolbar: Copy / Report equal-width --------------------
+    // --- Bottom toolbar: Copy / Clear / Report, equal-width -----------
     ImGui::Spacing();
-    const float util_w{equal_button_width(2)};
+    const float util_w{equal_button_width(3)};
     if (action_button("Copy output", util_w, util_h)) {
         copy_output(state);
     }
     if (ImGui::IsItemHovered()) {
         tooltip_text("Copy the log and environment info to the clipboard");
+    }
+    ImGui::SameLine();
+    ImGui::BeginDisabled(state.log.empty());
+    if (action_button("Clear output", util_w, util_h)) {
+        clear_output(state);
+    }
+    ImGui::EndDisabled();
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        tooltip_text("Clear the log");
     }
     ImGui::SameLine();
     if (action_button("Report bug", util_w, util_h)) {
@@ -1173,8 +1190,7 @@ void draw_ui(app_state& state)
         tooltip_text("Open a pre-filled GitHub issue with the log attached");
     }
 
-    // Footer under the full-span row: Copied! left, version right.
-    // Copy/Report already ate the row - SameLine onto it would clip.
+    // Footer under the full-span row: Copied! left, version centered.
     ImGui::Spacing();
     const float footer_y{ImGui::GetCursorPosY()};
     if (state.copied_flash > 0.0F) {
@@ -1184,10 +1200,12 @@ void draw_ui(app_state& state)
     {
         const std::string version_text{std::format("v{}", gui_version)};
         const float text_width{ImGui::CalcTextSize(version_text.c_str()).x};
-        ImGui::SetCursorPos(
-            ImVec2(ImGui::GetWindowContentRegionMax().x - text_width,
-                   footer_y));
-        ImGui::TextDisabled("%s", version_text.c_str());
+        const float content_min{ImGui::GetWindowContentRegionMin().x};
+        const float content_max{ImGui::GetWindowContentRegionMax().x};
+        ImGui::SetCursorPos(ImVec2(
+            content_min + ((content_max - content_min) - text_width) * 0.5F,
+            footer_y));
+        text_disabled(version_text);
         if (ImGui::IsItemHovered()) {
             tooltip_text(std::string(SDL_GetPlatform()) + " " +
                          std::string(target_arch));


### PR DESCRIPTION
# Pull Request

## Summary
Restacks the GUI: larger adaptive window, path field with Browse on the same row, equal-width Patch / Restore / Download WeMod under it, Settings as a collapsing header (no extra window), equal-width Copy / Report on the bottom. Default imgui theme colors untouched; padding/spacing opened for hit targets.

## Related Issue
No issue — GUI layout polish.

## Changes
- `src/gui/main.cpp` — layout rework of `draw_ui()` / `SDL_AppInit()`; default `StyleColorsDark()` colors untouched:
  - Window size is a fraction of the usable display (clamped 880x600 .. 1680x1050, fallback 1024x680) so FHD / 1440p / 4K open comfortably. `SDL_SetWindowMinimumSize` keeps resize from collapsing the layout. `FontScaleDpi` still scales widgets.
  - Path row: WeMod folder field + `Browse...` on one line.
  - Action row under the path: `Patch` / `Restore` always, `Download WeMod` only while the folder is unresolved. Buttons share the row equally (`equal_button_width`) at 2.0x frame height.
  - Status line under the actions.
  - Settings is a collapsing header again (collapsed by default, full width) — no floating window.
  - Log fills the rest. `Copy output` / `Report bug` share one equal-width full-span row at 1.55x frame height. Footer under it: Copied! left, version right.
  - Style density only: Window/Frame/Item padding opened so hit targets read like a settings page. Colors stay default dark.
- `cmake/cpm/imgui-config.cmake` — imgui `1.92.9` → `1.92.9b` (hotfix). No API changes.

Stack (C++23, SDL3 `3.4.14`, ImGui `1.92.9b`) and everything else — helpers, probing, commands, SDL callbacks — unchanged.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [x] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features) — no doc changes needed: no features added
- [ ] `docker build` succeeds if Dockerfiles changed

**Not verified locally** (CI should cover): compile on all presets, clang-format/clang-tidy pass, visual check of the layout at FHD / 1440p / 4K / HiDPI.

## Notes for Reviewer
- Default theme colors deliberately untouched — hierarchy comes from alignment, padding and scale, not colors.
- `Download WeMod` appearing/disappearing changes the action-row count (2 vs 3 equal slices); Patch and Restore stay on the same row, never jump.
- Settings is `CollapsingHeader` again, same place as before. No extra window.
