### PR TITLE
fix(gui): HiDPI render scale + Linux Clang release artifact

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -65,7 +65,9 @@ jobs:
                       preset: linux_clang_amd64_full
                       artifact-name: linux-clang-amd64
                       build-dir: build/linux_clang_amd64
-                      install-deps: ''
+                      install-deps: |-
+                          sudo apt-get update
+                          sudo apt-get install -y clang lld ninja-build
                     - os: ubuntu-24.04-arm
                       preset: linux_gcc_arm64_full
                       artifact-name: linux-gcc-arm64

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -73,6 +73,13 @@ jobs:
                       artifact-name: linux-gcc-arm64
                       build-dir: build/linux_gcc_arm64
                       install-deps: ''
+                    - os: ubuntu-24.04-arm
+                      preset: linux_clang_arm64_full
+                      artifact-name: linux-clang-arm64
+                      build-dir: build/linux_clang_arm64
+                      install-deps: |-
+                          sudo apt-get update
+                          sudo apt-get install -y clang lld ninja-build
 
         steps:
             - name: checkout

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -203,6 +203,56 @@ jobs:
           path: build/linux_gcc_amd64/*.tar.xz
           if-no-files-found: error
 
+  # ── Clang Linux AMD64 (matches the local Linux toolchain) ──────────────────
+  linux_clang_amd64:
+    name: linux-clang-amd64
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+
+      - name: cache_dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CPM_SOURCE_CACHE }}
+          key: cpm-${{ runner.os }}-clang-${{ hashFiles('**/CMakeLists.txt', '**/cmake/**/*.cmake') }}
+
+      - name: install_sdl3_dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+              build-essential git make pkg-config clang lld ninja-build \
+              libasound2-dev libpulse-dev libaudio-dev \
+              libfribidi-dev libjack-dev libsndio-dev \
+              libx11-dev libxext-dev libxrandr-dev libxcursor-dev \
+              libxfixes-dev libxi-dev libxss-dev libxtst-dev \
+              libxkbcommon-dev libdrm-dev libgbm-dev \
+              libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev \
+              libdbus-1-dev libibus-1.0-dev libudev-dev \
+              libthai-dev libusb-1.0-0-dev \
+              libpipewire-0.3-dev libwayland-dev libdecor-0-dev \
+              liburing-dev
+
+      - name: build_and_package
+        run: cmake --workflow --preset linux_clang_amd64_full
+
+      - name: rename_artifact
+        run: |
+          cd build/linux_clang_amd64
+          for f in *.tar.xz; do
+            mv "$f" "wemod_enhancer-linux-clang-amd64.tar.xz"
+          done
+
+      - name: upload_artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-clang-amd64
+          path: build/linux_clang_amd64/*.tar.xz
+          if-no-files-found: error
+
   # ── GCC Linux ARM64 (Steam Deck / ARM handhelds) ───────────────────────────
   linux_gcc_arm64:
     name: linux-gcc-arm64
@@ -261,6 +311,7 @@ jobs:
       - windows_clang_amd64
       - windows_msvc_amd64
       - linux_gcc_amd64
+      - linux_clang_amd64
       - linux_gcc_arm64
     runs-on: ubuntu-latest
     permissions:
@@ -303,6 +354,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: linux-amd64
+          path: artifacts/
+
+      - name: download_linux_clang_amd64_artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-clang-amd64
           path: artifacts/
 
       - name: download_linux_arm64_artifact

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -303,6 +303,56 @@ jobs:
           path: build/linux_gcc_arm64/*.tar.xz
           if-no-files-found: error
 
+  # ── Clang Linux ARM64 (Steam Deck / ARM handhelds) ─────────────────────────
+  linux_clang_arm64:
+    name: linux-clang-arm64
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+
+      - name: cache_dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CPM_SOURCE_CACHE }}
+          key: cpm-${{ runner.os }}-clang-arm64-${{ hashFiles('**/CMakeLists.txt', '**/cmake/**/*.cmake') }}
+
+      - name: install_sdl3_dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+              build-essential git make pkg-config clang lld ninja-build \
+              libasound2-dev libpulse-dev libaudio-dev \
+              libfribidi-dev libjack-dev libsndio-dev \
+              libx11-dev libxext-dev libxrandr-dev libxcursor-dev \
+              libxfixes-dev libxi-dev libxss-dev libxtst-dev \
+              libxkbcommon-dev libdrm-dev libgbm-dev \
+              libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev \
+              libdbus-1-dev libibus-1.0-dev libudev-dev \
+              libthai-dev libusb-1.0-0-dev \
+              libpipewire-0.3-dev libwayland-dev libdecor-0-dev \
+              liburing-dev
+
+      - name: build_and_package
+        run: cmake --workflow --preset linux_clang_arm64_full
+
+      - name: rename_artifact
+        run: |
+          cd build/linux_clang_arm64
+          for f in *.tar.xz; do
+            mv "$f" "wemod_enhancer-linux-clang-arm64.tar.xz"
+          done
+
+      - name: upload_artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-clang-arm64
+          path: build/linux_clang_arm64/*.tar.xz
+          if-no-files-found: error
+
   # ── Create GitHub Release ──────────────────────────────────────────────────
   release:
     name: Create Release
@@ -313,6 +363,7 @@ jobs:
       - linux_gcc_amd64
       - linux_clang_amd64
       - linux_gcc_arm64
+      - linux_clang_arm64
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -366,6 +417,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: linux-arm64
+          path: artifacts/
+
+      - name: download_linux_clang_arm64_artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-clang-arm64
           path: artifacts/
 
       - name: generate_release_notes

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -101,6 +101,17 @@
             "description": "Build the Linux ARM64 package natively with GCC (version.dll via nested llvm-mingw)",
             "inherits": "linux_gcc_amd64",
             "binaryDir": "${sourceDir}/build/${presetName}"
+        },
+        {
+            "name": "linux_clang_arm64",
+            "displayName": "Linux ARM64 (Clang)",
+            "description": "Build the Linux ARM64 package natively with Clang (version.dll via nested llvm-mingw)",
+            "inherits": "linux_gcc_arm64",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++"
+            }
         }
     ],
     "buildPresets": [
@@ -138,6 +149,12 @@
             "name": "linux_gcc_arm64",
             "displayName": "Linux ARM64 (GCC) RelWithDebInfo",
             "configurePreset": "linux_gcc_arm64",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "linux_clang_arm64",
+            "displayName": "Linux ARM64 (Clang) RelWithDebInfo",
+            "configurePreset": "linux_clang_arm64",
             "configuration": "RelWithDebInfo"
         }
     ],
@@ -201,6 +218,17 @@
             "name": "linux_gcc_arm64_package",
             "displayName": "Linux ARM64 (GCC) Package",
             "configurePreset": "linux_gcc_arm64",
+            "configurations": [
+                "RelWithDebInfo"
+            ],
+            "generators": [
+                "TXZ"
+            ]
+        },
+        {
+            "name": "linux_clang_arm64_package",
+            "displayName": "Linux ARM64 (Clang) Package",
+            "configurePreset": "linux_clang_arm64",
             "configurations": [
                 "RelWithDebInfo"
             ],
@@ -321,6 +349,25 @@
                 {
                     "type": "package",
                     "name": "linux_gcc_arm64_package"
+                }
+            ]
+        },
+        {
+            "name": "linux_clang_arm64_full",
+            "displayName": "Linux ARM64 (Clang) Pipeline",
+            "description": "Configure, build (RelWithDebInfo) and package natively on Linux ARM64 with Clang",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "linux_clang_arm64"
+                },
+                {
+                    "type": "build",
+                    "name": "linux_clang_arm64"
+                },
+                {
+                    "type": "package",
+                    "name": "linux_clang_arm64_package"
                 }
             ]
         }

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -38,8 +38,11 @@
 //     full-span row; Copied! left and the version centered on the
 //     footer line under it.
 //   - Window size is a fraction of the usable display (clamped) so
-//     FHD / 1440p / 4K all open comfortably; FontScaleDpi scales
-//     every font-size-derived widget.
+//     FHD / 1440p / 4K all open comfortably. DPI: FontScaleDpi +
+//     ScaleAllSizes + SDL_SetRenderScale, matching imgui's
+//     SDL3+SDL_Renderer example. Skip the render scale and the UI
+//     sits in the top-left corner on Wayland/HiDPI, with InputText
+//     hints clipped.
 //
 // C++ Core Guidelines, applied where they cost nothing:
 //   - No owning raw pointers, no new/delete, no C casts; const and
@@ -70,10 +73,12 @@
 //     not throw on a half-installed WeMod.
 //   - ImGui widget widths are computed from the font size
 //     (CalcTextSize / GetFrameHeight), so nothing clips at any DPI.
-//   - One scale factor for the whole UI: style.FontScaleDpi at init
-//     scales every font-size-derived widget (ImGui 1.92+); the window
-//     is created at logical size, so SDL keeps the physical size
-//     constant across DPIs.
+//   - DPI follows imgui's SDL3+SDL_Renderer example: FontScaleDpi and
+//     ScaleAllSizes at init, SDL_SetRenderScale(DisplayFramebufferScale)
+//     every frame. Window size stays in SDL window coordinates
+//     (pick_window_size uses usable bounds); HIGH_PIXEL_DENSITY then
+//     gives a larger framebuffer. Do not also multiply the window by
+//     the content scale - usable bounds are already in that space.
 //   - Folder validity is an INVARIANT of the current field text:
 //     resolve_wemod_dir() re-runs on edits and a 500 ms timer (never
 //     every frame - it walks directories), so the field can never
@@ -178,11 +183,12 @@ constexpr std::size_t log_budget{512UZ * 1024UZ};
 constexpr std::string_view default_python{
     is_windows ? std::string_view("python") : std::string_view("python3")};
 
-// Fallback logical window size when the display cannot be queried.
+// Fallback window size when the display cannot be queried.
 // pick_window_size() uses a fraction of the usable display so FHD /
-// 1440p / 4K all get a comfortable default; FontScaleDpi then scales
-// every font-size-derived widget. SDL keeps the physical size
-// constant across DPIs because the window is created at logical size.
+// 1440p / 4K all get a comfortable default. Units are SDL window
+// coordinates (same as SDL_GetDisplayUsableBounds); HiDPI is
+// FontScaleDpi + ScaleAllSizes + SDL_SetRenderScale, not a second
+// multiply on this size.
 constexpr std::int32_t window_width_fallback{1024};
 constexpr std::int32_t window_height_fallback{680};
 constexpr std::int32_t window_min_width{880};
@@ -341,7 +347,7 @@ void append_log(app_state& state, const std::string_view text)
 
 // Quote one argument for the shell that runs our background commands:
 // cmd.exe on Windows (double quotes, "" escapes a quote), /bin/sh
-// elsewhere (single quotes, '"''"'"' escapes a quote).
+// elsewhere (single quotes, '"'"' escapes a quote).
 [[nodiscard]] std::string shell_quote(const std::string_view arg)
 {
     if constexpr (is_windows) {
@@ -843,9 +849,10 @@ void report_bug(app_state& state)
     }
 }
 
-// Comfortable logical window size: a fraction of the usable display,
-// clamped so laptops stay usable and 4K does not open a postage stamp.
-// HiDPI is FontScaleDpi's job - this only picks the window.
+// Comfortable window size in SDL window coordinates: a fraction of
+// the usable display, clamped so laptops stay usable and 4K does not
+// open a postage stamp. HiDPI is FontScaleDpi + ScaleAllSizes +
+// SDL_SetRenderScale - this only picks the window.
 [[nodiscard]] std::pair<std::int32_t, std::int32_t> pick_window_size()
 {
     SDL_Rect usable{};
@@ -979,8 +986,11 @@ void draw_settings(app_state& state)
         "Windows, python3 elsewhere. Point it at a full path if "
         "Python is not on PATH.",
         "https://www.python.org/downloads/");
-    ImGui::SameLine();
+    // Version rides next to the label, not the field. An unconditional
+    // SameLine put the input on the label row (narrow, shifted) while
+    // Patcher / version.dll stayed full-width below their labels.
     if (state.python_ok == probe_state::works) {
+        ImGui::SameLine();
         text_disabled(state.python_version);
     }
     const bool python_tinted{state.python_ok != probe_state::unknown};
@@ -1255,6 +1265,11 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
         return SDL_APP_FAILURE;
     }
 
+    // Content scale is the expected UI scale for this display. 0 means
+    // unknown - never feed that to FontScaleDpi or every widget zeros.
+    const float display_scale{SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay())};
+    const float main_scale{display_scale > 0.0F ? display_scale : 1.0F};
+
     const auto [win_w, win_h]{pick_window_size()};
 
     SDL_Window* window{nullptr};
@@ -1268,6 +1283,7 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
         return SDL_APP_FAILURE;
     }
     SDL_SetWindowMinimumSize(window, window_min_width, window_min_height);
+    SDL_SetRenderVSync(renderer, 1);
 
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
@@ -1284,14 +1300,11 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
     style.ScrollbarSize = 16.0F;
     style.GrabMinSize = 14.0F;
 
-    // One knob scales the whole UI: style.FontScaleDpi (ImGui 1.92+)
-    // scales every font-size-derived widget, and the window was
-    // created at logical size so SDL keeps the physical size constant
-    // across DPIs. SDL returns 0.0 when the scale is unknown - that
-    // would zero every widget, so fall back to 1.0.
-    const float main_scale{SDL_GetDisplayContentScale(
-        SDL_GetPrimaryDisplay())};
-    style.FontScaleDpi = main_scale > 0.0F ? main_scale : 1.0F;
+    // imgui SDL3+SDL_Renderer example: bake padding, then DPI-scale
+    // the font. ScaleAllSizes is not idempotent - once, at init.
+    // SDL_SetRenderScale(DisplayFramebufferScale) runs every frame.
+    style.ScaleAllSizes(main_scale);
+    style.FontScaleDpi = main_scale;
 
     ImGui_ImplSDL3_InitForSDLRenderer(window, renderer);
     ImGui_ImplSDLRenderer3_Init(renderer);
@@ -1352,6 +1365,12 @@ SDL_AppResult SDL_AppIterate(void* appstate)
 
     poll_run(state);
 
+    // Keep font DPI in sync when the window moves between displays.
+    // ScaleAllSizes stays at the init bake (not idempotent).
+    if (const float dpi{SDL_GetWindowDisplayScale(state.window)}; dpi > 0.0F) {
+        ImGui::GetStyle().FontScaleDpi = dpi;
+    }
+
     ImGui_ImplSDLRenderer3_NewFrame();
     ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
@@ -1359,6 +1378,13 @@ SDL_AppResult SDL_AppIterate(void* appstate)
     draw_ui(state);
 
     ImGui::Render();
+    // Map imgui window coordinates onto the HIGH_PIXEL_DENSITY
+    // framebuffer. The SDL_Renderer backend skips its own clip-scale
+    // when a render scale is already set (rsx != 1), so this is the
+    // one knob - same call as imgui's example_sdl3_sdlrenderer3.
+    const ImGuiIO& io{ImGui::GetIO()};
+    SDL_SetRenderScale(state.renderer, io.DisplayFramebufferScale.x,
+                       io.DisplayFramebufferScale.y);
     SDL_SetRenderDrawColorFloat(state.renderer, clear_color.x,
                                 clear_color.y, clear_color.z,
                                 clear_color.w);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -38,11 +38,13 @@
 //     full-span row; Copied! left and the version centered on the
 //     footer line under it.
 //   - Window size is a fraction of the usable display (clamped) so
-//     FHD / 1440p / 4K all open comfortably. DPI: FontScaleDpi +
-//     ScaleAllSizes + SDL_SetRenderScale, matching imgui's
-//     SDL3+SDL_Renderer example. Skip the render scale and the UI
-//     sits in the top-left corner on Wayland/HiDPI, with InputText
-//     hints clipped.
+//     FHD / 1440p / 4K all open comfortably. DPI is one knob:
+//     SDL_SetRenderScale(DisplayFramebufferScale) maps imgui window
+//     coordinates onto the HIGH_PIXEL_DENSITY framebuffer. Skip that
+//     and the UI sits in the top-left corner on Wayland/HiDPI, with
+//     InputText hints clipped. Do not also bake FontScaleDpi /
+//     ScaleAllSizes to the display scale - that double-counts and
+//     widgets go ~2x too big.
 //
 // C++ Core Guidelines, applied where they cost nothing:
 //   - No owning raw pointers, no new/delete, no C casts; const and
@@ -73,12 +75,12 @@
 //     not throw on a half-installed WeMod.
 //   - ImGui widget widths are computed from the font size
 //     (CalcTextSize / GetFrameHeight), so nothing clips at any DPI.
-//   - DPI follows imgui's SDL3+SDL_Renderer example: FontScaleDpi and
-//     ScaleAllSizes at init, SDL_SetRenderScale(DisplayFramebufferScale)
-//     every frame. Window size stays in SDL window coordinates
-//     (pick_window_size uses usable bounds); HIGH_PIXEL_DENSITY then
-//     gives a larger framebuffer. Do not also multiply the window by
-//     the content scale - usable bounds are already in that space.
+//   - DPI: SDL_SetRenderScale(DisplayFramebufferScale) every frame.
+//     Window size stays in SDL window coordinates (pick_window_size
+//     uses usable bounds); HIGH_PIXEL_DENSITY then gives a larger
+//     framebuffer. Layout and fonts stay 1x in window coords. Do
+//     not also set FontScaleDpi / ScaleAllSizes to the content
+//     scale - that double-counts on HiDPI (~2x too big).
 //   - Folder validity is an INVARIANT of the current field text:
 //     resolve_wemod_dir() re-runs on edits and a 500 ms timer (never
 //     every frame - it walks directories), so the field can never
@@ -186,9 +188,8 @@ constexpr std::string_view default_python{
 // Fallback window size when the display cannot be queried.
 // pick_window_size() uses a fraction of the usable display so FHD /
 // 1440p / 4K all get a comfortable default. Units are SDL window
-// coordinates (same as SDL_GetDisplayUsableBounds); HiDPI is
-// FontScaleDpi + ScaleAllSizes + SDL_SetRenderScale, not a second
-// multiply on this size.
+// coordinates (same as SDL_GetDisplayUsableBounds). HiDPI is
+// SDL_SetRenderScale, not a second multiply on this size.
 constexpr std::int32_t window_width_fallback{1024};
 constexpr std::int32_t window_height_fallback{680};
 constexpr std::int32_t window_min_width{880};
@@ -851,8 +852,8 @@ void report_bug(app_state& state)
 
 // Comfortable window size in SDL window coordinates: a fraction of
 // the usable display, clamped so laptops stay usable and 4K does not
-// open a postage stamp. HiDPI is FontScaleDpi + ScaleAllSizes +
-// SDL_SetRenderScale - this only picks the window.
+// open a postage stamp. HiDPI is SDL_SetRenderScale - this only
+// picks the window.
 [[nodiscard]] std::pair<std::int32_t, std::int32_t> pick_window_size()
 {
     SDL_Rect usable{};
@@ -1265,11 +1266,6 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
         return SDL_APP_FAILURE;
     }
 
-    // Content scale is the expected UI scale for this display. 0 means
-    // unknown - never feed that to FontScaleDpi or every widget zeros.
-    const float display_scale{SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay())};
-    const float main_scale{display_scale > 0.0F ? display_scale : 1.0F};
-
     const auto [win_w, win_h]{pick_window_size()};
 
     SDL_Window* window{nullptr};
@@ -1292,6 +1288,10 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
     // Density only: default dark colors stay. Opened padding matches
     // the settings-page habit (generous hit targets, even gaps) so
     // FHD and 4K both read as the same layout, just larger.
+    // Padding stays 1x in window coordinates. SDL_SetRenderScale
+    // (DisplayFramebufferScale) maps those onto the HiDPI framebuffer
+    // every frame. Baking FontScaleDpi / ScaleAllSizes on top of that
+    // double-counts and the UI goes ~2x too big.
     ImGuiStyle& style{ImGui::GetStyle()};
     style.WindowPadding = ImVec2(16.0F, 14.0F);
     style.FramePadding = ImVec2(14.0F, 8.0F);
@@ -1299,12 +1299,6 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char* argv[])
     style.ItemInnerSpacing = ImVec2(8.0F, 6.0F);
     style.ScrollbarSize = 16.0F;
     style.GrabMinSize = 14.0F;
-
-    // imgui SDL3+SDL_Renderer example: bake padding, then DPI-scale
-    // the font. ScaleAllSizes is not idempotent - once, at init.
-    // SDL_SetRenderScale(DisplayFramebufferScale) runs every frame.
-    style.ScaleAllSizes(main_scale);
-    style.FontScaleDpi = main_scale;
 
     ImGui_ImplSDL3_InitForSDLRenderer(window, renderer);
     ImGui_ImplSDLRenderer3_Init(renderer);
@@ -1365,12 +1359,6 @@ SDL_AppResult SDL_AppIterate(void* appstate)
 
     poll_run(state);
 
-    // Keep font DPI in sync when the window moves between displays.
-    // ScaleAllSizes stays at the init bake (not idempotent).
-    if (const float dpi{SDL_GetWindowDisplayScale(state.window)}; dpi > 0.0F) {
-        ImGui::GetStyle().FontScaleDpi = dpi;
-    }
-
     ImGui_ImplSDLRenderer3_NewFrame();
     ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
@@ -1379,9 +1367,10 @@ SDL_AppResult SDL_AppIterate(void* appstate)
 
     ImGui::Render();
     // Map imgui window coordinates onto the HIGH_PIXEL_DENSITY
-    // framebuffer. The SDL_Renderer backend skips its own clip-scale
-    // when a render scale is already set (rsx != 1), so this is the
-    // one knob - same call as imgui's example_sdl3_sdlrenderer3.
+    // framebuffer. Layout stays 1x; this is the only DPI knob. The
+    // SDL_Renderer backend skips its own clip-scale when a render
+    // scale is already set (rsx != 1), so this is also what keeps
+    // InputText hints from being clipped.
     const ImGuiIO& io{ImGui::GetIO()};
     SDL_SetRenderScale(state.renderer, io.DisplayFramebufferScale.x,
                        io.DisplayFramebufferScale.y);


### PR DESCRIPTION
# Pull Request

## Summary
Fix the Linux CI artifact drawing the ImGui UI in the SDL window corner (hint glyphs gone), keep widgets at 1x size (no HiDPI double-count), and ship Linux Clang packages (AMD64 + ARM64) so GitHub artifacts match the local Clang build.

## Related Issue
No issue — GUI HiDPI / CI toolchain mismatch reported against GitHub artifacts vs a working local Linux Clang build.

## Changes
- `src/gui/main.cpp`
  - `SDL_SetRenderScale(io.DisplayFramebufferScale)` every frame. Without it, ImGui vertices stay in window coordinates while `SDL_WINDOW_HIGH_PIXEL_DENSITY` gives a larger framebuffer — UI sits top-left, `InputTextWithHint` clip rects swallow hint glyphs. Same class of bug as [imgui#7779](https://github.com/ocornut/imgui/issues/7779).
  - Do **not** bake `FontScaleDpi` / `ScaleAllSizes` to the display content scale. That stacks on top of the render scale and widgets go ~2x too big (the "overbig" follow-up). Layout stays 1x in window coords; the renderer does DPI.
  - Keep `pick_window_size()` in SDL window coordinates (usable display bounds). Do **not** also multiply by content scale.
  - Python command: `SameLine` only the probed version next to the **label**. The input stays on its own full-width row like Patcher / version.dll.
- `CMakePresets.json`
  - New `linux_clang_arm64` configure / build / package / workflow presets. Inherits `linux_gcc_arm64`, swaps gcc for clang, own `binaryDir`.
- `.github/workflows/cmake_multi_platform.yml`
  - `linux_clang_amd64` already in the matrix; install `clang lld ninja-build`.
  - New `linux_clang_arm64` matrix entry on `ubuntu-24.04-arm`.
- `.github/workflows/publish_release.yml`
  - `linux_clang_amd64` job → `wemod_enhancer-linux-clang-amd64.tar.xz`
  - `linux_clang_arm64` job → `wemod_enhancer-linux-clang-arm64.tar.xz`
  - Both attached to the GitHub Release next to the GCC tarballs.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed
- [x] Render scale still set every frame (window fill + unclipped hints)
- [x] No FontScaleDpi / ScaleAllSizes bake (no ~2x widgets)
- [x] Python field `SameLine` only wraps the version text
- [x] Window size still comes from usable bounds, not `size * content_scale`
- [x] `linux_clang_arm64_full` preset exists and is wired in CI + release

## Notes for Reviewer
- Local Linux Clang working + CI artifact broken is **not** a compiler ABI split. Same source, same SDL3/imgui. The missing piece is the HiDPI render scale.
- Follow-up on this PR: first HiDPI pass also baked FontScaleDpi + ScaleAllSizes. That double-counted (~2x). Dropped. One knob left: `SDL_SetRenderScale`.
- GCC Linux artifacts stay. Clang is extra: `linux-clang-amd64` and `linux-clang-arm64`.
- Other agent: this branch is `fix/gui-hidpi-linux-clang` only.
